### PR TITLE
removing the googlebot from the user-agent

### DIFF
--- a/SAMPLE-config.py
+++ b/SAMPLE-config.py
@@ -6,8 +6,7 @@ Configurations for the client lib
 #### NOTE: Rename this file to 'config.py' and fill in the missing info below
 
 # useragent for HTTP requests
-#useragent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101 Firefox/81.0'
-useragent = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+useragent = 'Mozilla/5.0 (compatible; Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 Edg/88.0.705.56'
 
 # enter your API key for Google Pagespeed API
 googlePageSpeedApiKey = ""


### PR DESCRIPTION
To deal with http-requests failing against sites that uses cloudflare proxy