### PR TITLE
F-strings supporting older Python versions

### DIFF
--- a/tests/email_validator.py
+++ b/tests/email_validator.py
@@ -210,7 +210,7 @@ def get_interesting_urls(content, org_url_start, depth):
                 r"(kontakt(a [a-z]+){0,1}|om [a-z]+|personuppgifter|(tillg(.{1,6}|ä|&auml;|&#228;)nglighet(sredog(.{1,6}|ö|&ouml;|&#246;)relse){0,1}))", flags=re.MULTILINE | re.IGNORECASE)):
             continue
 
-        url = f'{link.get('href')}'
+        url = f"{link.get('href')}"
 
         if url is None:
             continue

--- a/tests/lighthouse_base.py
+++ b/tests/lighthouse_base.py
@@ -133,7 +133,7 @@ def create_rating_from_audit(item, global_translation, weight):
         local_points = 5.0
 
     if 'title' in item:
-        item_title = f'{item['title']}'
+        item_title = f"{item['title']}"
 
     if 'description' in item:
         item_description = item['description']


### PR DESCRIPTION
Only apostrophys in f-strings do not play well with pre-python 3.12