### PR TITLE
webperf_core should not require config.py creation

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,6 +23,8 @@ import dns.dnssec
 import dns.exception
 import dns.name
 
+CONFIG_WARNINGS = {}
+
 def get_config_or_default(name):
     """
     Retrieves the configuration value for a given name from the configuration file.
@@ -46,25 +48,47 @@ def get_config_or_default(name):
       a fatal error message is printed and a ValueError is raised.
     """
     # Try get config from our configuration file
-    import config # pylint: disable=import-outside-toplevel
-    if hasattr(config, name):
-        return getattr(config, name)
+    value = get_config_from_module(name, 'config')
+    if value is not None:
+        return value
 
     name = name.upper()
-    if hasattr(config, name):
-        return getattr(config, name)
+    value = get_config_from_module(name, 'config')
+    if value is not None:
+        return value
 
     # do we have fallback value we can use in our SAMPLE-config.py file?
-    from importlib import import_module # pylint: disable=import-outside-toplevel
-    SAMPLE_config = import_module('SAMPLE-config') # pylint: disable=invalid-name
-    if hasattr(SAMPLE_config, name):
-        print(f'Warning: "{name}" is missing in your config.py file,'
-              'using value from SAMPLE-config.py')
-        return getattr(SAMPLE_config, name)
+    value = get_config_from_module(name, 'SAMPLE-config')
+    if value is not None:
+        if name not in CONFIG_WARNINGS:
+            CONFIG_WARNINGS[name] = True
+            print(f'Warning: "{name}" is missing in your config.py file, '
+                'using default value from SAMPLE-config.py')
+        return value
 
-    print(f'FATAL: "{name}" is missing in your config.py and SAMPLE-config.py files')
-    raise ValueError(f'FATAL: "{name}" is missing in your config.py and SAMPLE-config.py files')
+    return None
 
+def get_config_from_module(config_name, module_name):
+    """
+    Retrieves the configuration value for a given name from the specified module file.
+    
+    Parameters:
+    config_name (str): The name of the configuration value to retrieve.
+    module_name (str): The name of the module the values should be retrieved from.
+
+    Returns:
+    The configuration value associated with the given config_name and module_name.
+    """
+    # do we have fallback value we can use in our SAMPLE-config.py file?
+    try:
+        from importlib import import_module # pylint: disable=import-outside-toplevel
+        tmp_config = import_module(module_name) # pylint: disable=invalid-name
+        if hasattr(tmp_config, config_name):
+            return getattr(tmp_config, config_name)
+    except ModuleNotFoundError:
+        _ = 1
+
+    return None
 
 def get_translation(module_name, lang_code):
     """


### PR DESCRIPTION
The Benefits of Directly Using SAMPLE-config.py and the Importance of config.py in webperf_core

The direct use of `SAMPLE-config.py` in `webperf_core`, without the need for manual copying and renaming to `config.py`, offers several advantages that significantly enhance the user experience. However, the role of `config.py` remains crucial for custom configurations. Here are some key points to consider:

1. **Simplicity and Accessibility**: The direct use of `SAMPLE-config.py` eliminates the need for manual copying and renaming, simplifying the setup process. This makes `webperf_core` more user-friendly, especially for beginners.

2. **Time Efficiency**: By removing the manual step of creating a `config.py` file, users can get started with `webperf_core` more quickly. This allows users to focus more on optimizing web performance and less on setup procedures.

3. **Error Reduction**: The risk of errors that could occur during the manual copying and renaming process is eliminated. This leads to a smoother and more enjoyable user experience.

4. **Consistency**: Directly using `SAMPLE-config.py` ensures that all users start with a consistent setup. This uniformity is beneficial for troubleshooting and collaboration.

5. **Customization with config.py**: While `SAMPLE-config.py` provides a great starting point, `config.py` is essential when users want to deviate from the standard settings. Users **SHOULD** use `config.py` for custom configurations to tailor `webperf_core` to their specific needs.