### PR TITLE
Use version specific w3c validator for HTML/CSS Tests

### DIFF
--- a/.github/workflows/regression-test-css.yml
+++ b/.github/workflows/regression-test-css.yml
@@ -33,14 +33,8 @@ jobs:
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt
-    - if: ${{ matrix.os == 'ubuntu-latest' }}
-      name: Download vnu.jar (The Nu Html Checker) - Linux
-      run: wget -q -O vnu.jar https://github.com/validator/validator/releases/download/latest/vnu.jar
-    - if: ${{ matrix.os == 'windows-latest' }}
-      shell: pwsh
-      name: Download vnu.jar (The Nu Html Checker) - Windows
-      run: |
-        Invoke-WebRequest -Uri https://github.com/validator/validator/releases/download/latest/vnu.jar -OutFile vnu.jar
+    - name: Java Version
+      run: java -version
     - name: Setup Node.js (v4 version 20.x)
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/regression-test-html.yml
+++ b/.github/workflows/regression-test-html.yml
@@ -33,14 +33,8 @@ jobs:
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt
-    - if: ${{ matrix.os == 'ubuntu-latest' }}
-      name: Download vnu.jar (The Nu Html Checker) - Linux
-      run: wget -q -O vnu.jar https://github.com/validator/validator/releases/download/latest/vnu.jar
-    - if: ${{ matrix.os == 'windows-latest' }}
-      shell: pwsh
-      name: Download vnu.jar (The Nu Html Checker) - Windows
-      run: |
-        Invoke-WebRequest -Uri https://github.com/validator/validator/releases/download/latest/vnu.jar -OutFile vnu.jar
+    - name: Java Version
+      run: java -version
     - name: Setup Node.js (v4 version 20.x)
       uses: actions/setup-node@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,6 @@ RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc, /usr/sbin/route, /usr/sbin/ip' > /etc/
 
 RUN npm install -g node-gyp puppeteer
 
-RUN wget -q -O vnu.jar https://github.com/validator/validator/releases/download/latest/vnu.jar
-
 # If own config.py exists it will overwrite the SAMPLE
 COPY . /usr/src/app
 

--- a/docs/tests/css.md
+++ b/docs/tests/css.md
@@ -48,7 +48,6 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Depending on your preference, follow below NPM package or Docker image steps below.
 
 * Download and install Java (JDK 8 or above)
-* [Download latest vnu.jar](https://github.com/validator/validator/releases/download/latest/vnu.jar) and place it in your webperf-core directory
 
 #### Using NPM package
 

--- a/docs/tests/html.md
+++ b/docs/tests/html.md
@@ -38,7 +38,6 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Depending on your preference, follow below NPM package or Docker image steps below.
 
 * Download and install Java (JDK 8 or above)
-* [Download latest vnu.jar](https://github.com/validator/validator/releases/download/latest/vnu.jar) and place it in your webperf-core directory
 
 #### Using NPM package
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lighthouse": "12.0.0",
     "pa11y": "8.0.0",
     "sitespeed.io": "33.6.0",
+    "vnu-jar": "23.4.11",
     "yellowlabtools": "3.0.1"
   },
   "engines": {

--- a/tests/w3c_base.py
+++ b/tests/w3c_base.py
@@ -77,7 +77,9 @@ def get_errors(test_type, params):
 
         arg = f'--exit-zero-always{test_arg} --stdout --format json --errors-only {file_path}'
 
-    command = f'java -jar vnu.jar {arg}'
+    command = (f'java -jar node_modules{os.path.sep}vnu-jar'
+               f'{os.path.sep}build{os.path.sep}dist{os.path.sep}'
+               f'vnu.jar {arg}')
     with subprocess.Popen(command.split(), stdout=subprocess.PIPE) as process:
         output, _ = process.communicate(timeout=REQUEST_TIMEOUT * 10)
 


### PR DESCRIPTION
They made a pre-release called "latest" that breaks.
Changed to use version specific version from now on.

#465

Labels:
   - `enhancement`
   - `bug`
