### PR TITLE
Clear `failures.log` file on every new run

### DIFF
--- a/default.py
+++ b/default.py
@@ -24,7 +24,7 @@ from engines.gov import write_tests as gov_write_tests
 from engines.sql import write_tests as sql_write_tests
 from engines.markdown_engine import write_tests as markdown_write_tests
 from tests.utils import clean_cache_files
-from utils import TEST_FUNCS, TEST_ALL, test_sites
+from utils import TEST_FUNCS, TEST_ALL, restart_failures_log, test_sites
 
 
 def validate_test_type(tmp_test_types):
@@ -493,6 +493,7 @@ def main(argv):
             options.input_skip,
             options.input_take)
     elif len(options.sites) > 0:
+        restart_failures_log()
         # run test(s) for every website
         test_results = test_sites(options.language,
                                         options.lang_code,

--- a/utils.py
+++ b/utils.py
@@ -197,6 +197,14 @@ def test(global_translation, lang_code, site, test_type=None, show_reviews=False
 
     return []
 
+def restart_failures_log():
+    """
+    Restart failures log by removing all content in it,
+    this is so we always start fresh.
+    """
+    with open('failures.log', 'w', encoding='utf-8') as outfile:
+        outfile.writelines('')
+
 def get_error_info(url, lang_code, test_type, show_reviews, ex):
     result = []
     result.append('###############################################')


### PR DESCRIPTION
`failures.log` can be looooong and big after a while of running it.
It is also hard to find correct error when reporting it.

Lets solve that by empy it at the start of every run.