### PR TITLE
Add show in terminal option to settings.json

### DIFF
--- a/default.py
+++ b/default.py
@@ -162,7 +162,6 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
     setting_filename = ''
     input_skip = 0
     input_take = -1
-    show_reviews = False
     add_url = ''
     delete_url = ''
     lang_code = 'en'
@@ -341,7 +340,7 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
     def enable_reviews(self, _):
         """
         Enables the display of reviews for the instance.
-        This function sets the `show_reviews` attribute of the instance to True,
+        This function sets the `general.review.show` to true,
         enabling the display of reviews.
 
         Args:
@@ -350,7 +349,7 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
         Returns:
             None
         """
-        self.show_reviews = True
+        self.set_setting('general.review.show=true')
 
     def set_input_handlers(self, input_filename):
         """
@@ -561,8 +560,7 @@ def main(argv):
         test_results = test_sites(options.language,
                                         options.lang_code,
                                         options.sites,
-                                        test_types=options.test_types,
-                                        show_reviews=options.show_reviews)
+                                        test_types=options.test_types)
 
         write_test_results(options.sites, options.output_filename, test_results, options.language)
             # Cleanup exipred cache

--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -7,6 +7,7 @@
             "timeout": 60
         },
         "review": {
+            "show": false,
             "details": false,
             "improve-only": true
         },

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -8,6 +8,9 @@ config = {}
 config_mapping = {
     ("useragent", "general.useragent", "USERAGENT"): "string|general.useragent",
     (
+        "review",
+        "general.review.show"): "bool|general.review.show",
+    (
         "details",
         "general.review.details",
         "use_detailed_report",

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@
 import json
 from datetime import datetime
 import traceback
-from helpers.setting_helper import get_used_configuration
+from helpers.setting_helper import get_config, get_used_configuration
 from models import SiteTests
 from tests.page_not_found import run_test as run_test_page_not_found
 from tests.html_validator_w3c import run_test as run_test_html_validator_w3c
@@ -61,7 +61,7 @@ TEST_FUNCS = {
 
 CONFIG_WARNINGS = {}
 
-def test(global_translation, lang_code, site, test_type=None, show_reviews=False):
+def test(global_translation, lang_code, site, test_type=None):
     """
     This function runs a specific test on a website and returns the test results.
 
@@ -75,8 +75,6 @@ def test(global_translation, lang_code, site, test_type=None, show_reviews=False
     test_type : str, optional
         The type of test to be run. If the test type is not in the predefined test functions,
         the function will return an empty list.
-    show_reviews : bool, optional
-        A flag indicating whether to print the reviews of the website. The default is False.
 
     Returns:
     list
@@ -99,7 +97,7 @@ def test(global_translation, lang_code, site, test_type=None, show_reviews=False
             rating = the_test_result[0]
             reviews = rating.get_reviews()
             print(global_translation('TEXT_SITE_RATING'), rating)
-            if show_reviews:
+            if get_config('general.review.show'):
                 print(global_translation('TEXT_SITE_REVIEW'),
                       reviews)
 
@@ -125,7 +123,7 @@ def test(global_translation, lang_code, site, test_type=None, show_reviews=False
     except Exception as ex: # pylint: disable=broad-exception-caught
         print(global_translation('TEXT_TEST_END').format(
             datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
-        info = get_error_info(site[1], lang_code, test_type, show_reviews, ex)
+        info = get_error_info(site[1], lang_code, test_type, ex)
         print('\n'.join(info).replace('\n\n','\n'))
 
         # write error to failure.log file
@@ -142,7 +140,7 @@ def restart_failures_log():
     with open('failures.log', 'w', encoding='utf-8') as outfile:
         outfile.writelines('')
 
-def get_error_info(url, lang_code, test_type, show_reviews, ex):
+def get_error_info(url, lang_code, test_type, ex):
     """
     Generate error information for diagnostic purposes.
 
@@ -154,7 +152,6 @@ def get_error_info(url, lang_code, test_type, show_reviews, ex):
         url (str): The URL associated with the error.
         lang_code (str): The language code.
         test_type (str): The type of test being performed.
-        show_reviews (bool): Whether to display reviews.
         ex (Exception): The exception object.
 
     Returns:
@@ -171,7 +168,6 @@ def get_error_info(url, lang_code, test_type, show_reviews, ex):
         f'\nUrl: {url}',
         f'\nLanguage Code: {lang_code}',
         f'\nTest Type(s): {test_type}',
-        f'\nShow Reviews: {show_reviews}',
         '\n###############################################'
         '\n# Used Configuration:'
     ])
@@ -226,7 +222,7 @@ def get_versions():
             result.append("\n")
     return result
 
-def test_site(global_translation, lang_code, site, test_types=TEST_ALL, show_reviews=False):
+def test_site(global_translation, lang_code, site, test_types=TEST_ALL):
     """
     This function runs a series of tests on a website and returns a list of all the test results.
 
@@ -239,8 +235,6 @@ def test_site(global_translation, lang_code, site, test_types=TEST_ALL, show_rev
         A tuple containing the site ID and the website URL.
     test_types : list, optional
         A list of test types to be run. If not provided, all tests will be run.
-    show_reviews : bool, optional
-        A flag indicating whether to print the reviews of the website. The default is False.
 
     Returns:
     list
@@ -253,13 +247,12 @@ def test_site(global_translation, lang_code, site, test_types=TEST_ALL, show_rev
             tests.extend(test(global_translation,
                             lang_code,
                             site,
-                            test_type=test_id,
-                            show_reviews=show_reviews))
+                            test_type=test_id))
 
     return tests
 
 
-def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL, show_reviews=False):
+def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL):
     """
     This function runs a series of tests on multiple websites and
     returns a list of all the test results.
@@ -273,8 +266,6 @@ def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL, show_r
         A list of tuples, each containing the site ID and the website URL.
     test_types : list, optional
         A list of test types to be run. If not provided, all tests will be run.
-    show_reviews : bool, optional
-        A flag indicating whether to print the reviews of the websites. The default is False.
 
     Returns:
     list
@@ -299,7 +290,7 @@ def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL, show_r
         if has_more_then_one_site:
             print(global_translation('TEXT_WEBSITE_X_OF_Y').format(site_index + 1, nof_sites))
         results.extend(test_site(global_translation, lang_code, site,
-                                 test_types, show_reviews))
+                                 test_types))
 
         site_index += 1
 


### PR DESCRIPTION
Today when running webperf-core you can specify to show review(s) in terminal by using `-r` or `--review` for current run.

In this PR we make it possible to specify it in `settings.json` and have it persistent between runs:

```json
{
    "general": {
        "review": {
            "show": false
        }
}
```

You can also use the longer form for use during current run:
`python default.py --setting general.review.show=true -i sites.json`

you should see this as the first steps of moving more and more options into `settings.json`.