### PR TITLE
Add language from terminal options to settings.json

### DIFF
--- a/default.py
+++ b/default.py
@@ -23,7 +23,7 @@ from engines.json_engine import read_sites as json_read_sites,\
 from engines.gov import write_tests as gov_write_tests
 from engines.sql import write_tests as sql_write_tests
 from engines.markdown_engine import write_tests as markdown_write_tests
-from helpers.setting_helper import config_mapping, set_config, set_config_from_cmd
+from helpers.setting_helper import config_mapping, get_config, set_config, set_config_from_cmd
 from tests.utils import clean_cache_files
 from utils import TEST_FUNCS, TEST_ALL, restart_failures_log, test_sites
 
@@ -164,7 +164,6 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
     input_take = -1
     add_url = ''
     delete_url = ''
-    lang_code = 'en'
     language = False
 
     read_sites = None
@@ -172,7 +171,7 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
     delete_site = None
 
     def __init__(self):
-        self.lang_code = 'en'
+        self.language = False
 
     def show_help(self, _):
         """
@@ -288,6 +287,8 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
         """
         if not set_config_from_cmd(arg):
             self.show_available_settings()
+        else:
+            self.load_language(get_config('general.language'))
 
     def set_output_filename(self, arg):
         """
@@ -437,10 +438,10 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
                 available_languages.append(locale_name)
 
                 if locale_name == arg:
-                    self.lang_code = arg
+                    set_config_from_cmd(f"general.language={arg}")
                     found_lang = True
 
-                    self.load_language(self.lang_code)
+                    self.load_language(arg)
 
         if not found_lang:
                     # Not translateable
@@ -509,7 +510,7 @@ def main(argv):
     """
 
     options = CommandLineOptions()
-    options.load_language(options.lang_code)
+    options.load_language(get_config('general.language'))
 
     try:
         opts, _ = getopt.getopt(argv, "hu:t:i:o:rA:D:L:s:", [
@@ -558,7 +559,6 @@ def main(argv):
         restart_failures_log()
         # run test(s) for every website
         test_results = test_sites(options.language,
-                                        options.lang_code,
                                         options.sites,
                                         test_types=options.test_types)
 

--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -3,6 +3,7 @@
         "dns": {
             "address": "8.8.8.8"
         },
+        "language": "en",
         "request": {
             "timeout": 60
         },

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -38,6 +38,10 @@ This section indicate the settings affects many test.
 Address to nameserver used for DNS lookups.
 Good if you for example have your own nameserver internally.
 
+### general.language `(Default = en)`
+
+This variable is used to specify what language to use both in terminal and reviews.
+
 ### general.request.timeout `(Default = 60)`
 
 This variable is used as request timeout where a single request is only needed and not a full browser simulation.

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -6,6 +6,7 @@ from pathlib import Path
 config = {}
 
 config_mapping = {
+    ("language", "general.language"): "string|general.language",
     ("useragent", "general.useragent", "USERAGENT"): "string|general.useragent",
     (
         "review",

--- a/tests/a11y_lighthouse.py
+++ b/tests/a11y_lighthouse.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
+from helpers.setting_helper import get_config
 from tests.lighthouse_base import run_test as lighthouse_base_run_test, get_lighthouse_translations
 
-def run_test(global_translation, lang_code, url, strategy='mobile', category='accessibility'):
+def run_test(global_translation, url, strategy='mobile', category='accessibility'):
     """
     Analyzes URL with Lighthouse Accessibility.
     """
 
-    translations = get_lighthouse_translations('a11y_lighthouse', lang_code, global_translation)
+    translations = get_lighthouse_translations(
+        'a11y_lighthouse',
+        get_config('general.language'),
+        global_translation)
     # pylint: disable=duplicate-code
     return lighthouse_base_run_test(
         url,

--- a/tests/a11y_pa11y.py
+++ b/tests/a11y_pa11y.py
@@ -7,7 +7,7 @@ from tests.utils import get_translation
 from helpers.setting_helper import get_config
 from models import Rating
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Runs an accessibility test on a given URL and returns the results and ratings.
 
@@ -17,13 +17,15 @@ def run_test(global_translation, lang_code, url):
 
     Parameters:
     global_translation (function): Function to translate text to a global language.
-    lang_code (str): The language code for the local translation.
     url (str): The URL to run the accessibility test on.
 
     Returns:
     tuple: A tuple containing the rating object and the results of the accessibility test.
     """
-    local_translation = get_translation('a11y_pa11y', lang_code)
+    local_translation = get_translation(
+            'a11y_pa11y',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/a11y_statement.py
+++ b/tests/a11y_statement.py
@@ -13,7 +13,7 @@ DIGG_URL = 'https://www.digg.se/tdosanmalan'
 checked_urls = {}
 canonical = 'https://www.digg.se/tdosanmalan' # pylint: disable=invalid-name
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Runs a test on a given URL and returns the rating and a dictionary.
 
@@ -23,13 +23,15 @@ def run_test(global_translation, lang_code, url):
 
     Parameters:
     global_translation (function): A function that provides global translation.
-    lang_code (str): The language code to be used for local translation.
     url (str): The URL to be tested.
 
     Returns:
     tuple: A tuple containing the rating (an instance of the Rating class) and a dictionary.
     """
-    local_translation = get_translation('a11y_statement', lang_code)
+    local_translation = get_translation(
+            'a11y_statement',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/best_practice_lighthouse.py
+++ b/tests/best_practice_lighthouse.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
+from helpers.setting_helper import get_config
 from tests.lighthouse_base import run_test as lighthouse_base_run_test, get_lighthouse_translations
 
-def run_test(global_translation, lang_code, url, strategy='mobile', category='best-practices'):
+def run_test(global_translation, url, strategy='mobile', category='best-practices'):
     """
     Analyzes URL with Lighthouse Best-practices.
     """
-    translations = get_lighthouse_translations('best_practice_lighthouse',
-                                               lang_code, global_translation)
+    translations = get_lighthouse_translations(
+        'best_practice_lighthouse',
+        get_config('general.language'),
+        global_translation)
     # pylint: disable=duplicate-code
     return lighthouse_base_run_test(
         url,

--- a/tests/css_validator_w3c.py
+++ b/tests/css_validator_w3c.py
@@ -14,12 +14,12 @@ from helpers.setting_helper import get_config
 # DEFAULTS
 GROUP_ERROR_MSG_REGEX = r"(“[^”]+”)"
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
 
-    local_translation = get_translation('css_validator_w3c', lang_code)
+    local_translation = get_translation('css_validator_w3c', get_config('general.language'))
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/email_validator.py
+++ b/tests/email_validator.py
@@ -114,12 +114,15 @@ class SmtpWebperf(smtplib.SMTP): # pylint: disable=too-many-instance-attributes,
         return (code, msg)
 
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
 
-    local_translation = get_translation('email_validator', lang_code)
+    local_translation = get_translation(
+            'email_validator',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/energy_efficiency.py
+++ b/tests/energy_efficiency.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+from helpers.setting_helper import get_config
 from models import Rating
 from tests import energy_efficiency_carbon_percentiles
 import tests.energy_efficiency_carbon_percentiles2022 as energy_efficiency_carbon_percentiles_2022
@@ -133,12 +134,15 @@ def format_bytes(size):
     return size, power_labels[n]+'b'
 
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Analyzes URL with Lighthouse and uses weight to calculate co2 and rate compared to other sites.
     """
 
-    local_translation = get_translation('energy_efficiency_websitecarbon', lang_code)
+    local_translation = get_translation(
+            'energy_efficiency_websitecarbon',
+            get_config('general.language')
+        )
 
     print(local_translation("TEXT_RUNNING_TEST"))
 
@@ -146,7 +150,9 @@ def run_test(global_translation, lang_code, url):
         datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
 
     result_dict = {}
-    transfer_bytes = get_total_bytes_for_url(global_translation, lang_code, url)
+    transfer_bytes = get_total_bytes_for_url(
+        global_translation,
+        url)
     if transfer_bytes is None:
         rating = Rating(global_translation)
         rating.overall_review = global_translation('TEXT_SITE_UNAVAILABLE')
@@ -202,23 +208,22 @@ def run_test(global_translation, lang_code, url):
 
     return (rating, result_dict)
 
-def get_total_bytes_for_url(global_translation, lang_code, url):
+def get_total_bytes_for_url(global_translation, url):
     """
     Runs a Lighthouse performance test on a given URL and returns the total byte weight of the page.
 
     This function is specifically designed to work with multilingual websites.
     It uses the 'global_translation'
-    and 'lang_code' parameters to handle the language-specific aspects of the website.
+    to handle the language-specific aspects of the website.
 
     Parameters:
     global_translation (dict): A dictionary containing language-specific translations.
-    lang_code (str): The language code for the specific language version of the website to test.
     url (str): The URL of the webpage to run the Lighthouse performance test on.
 
     Returns:
     int: The total byte weight of the webpage as determined by the Lighthouse performance test.
     """
-    lighthouse_perf_result = lighthouse_perf_run_test(global_translation, lang_code, url, True)
+    lighthouse_perf_result = lighthouse_perf_run_test(global_translation, url, True)
 
     if not lighthouse_perf_result[0].isused():
         return None

--- a/tests/frontend_quality_yellow_lab_tools.py
+++ b/tests/frontend_quality_yellow_lab_tools.py
@@ -7,13 +7,16 @@ from tests.utils import get_translation
 from helpers.setting_helper import get_config
 from models import Rating
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Analyzes URL with Yellow Lab Tools docker image.
     Devices might be; phone, tablet, desktop
     """
 
-    local_translation = get_translation('frontend_quality_yellow_lab_tools', lang_code)
+    local_translation = get_translation(
+            'frontend_quality_yellow_lab_tools',
+            get_config('general.language')
+        )
 
     rating = Rating(global_translation, get_config('general.review.improve-only'))
 

--- a/tests/html_validator_w3c.py
+++ b/tests/html_validator_w3c.py
@@ -18,12 +18,12 @@ HTML_START_STRINGS = [
     ]
 
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
 
-    local_translation = get_translation('html_validator_w3c', lang_code)
+    local_translation = get_translation('html_validator_w3c', get_config('general.language'))
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/http_validator.py
+++ b/tests/http_validator.py
@@ -22,7 +22,7 @@ from tests.sitespeed_base import get_result
 
 csp_only_global_result_dict = {}
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
@@ -31,7 +31,10 @@ def run_test(global_translation, lang_code, url):
 
     result_dict = {}
 
-    local_translation = get_translation('http_validator', lang_code)
+    local_translation = get_translation(
+            'http_validator',
+            get_config('general.language')
+        )
 
     if get_config('tests.http.csp-only'):
         print(local_translation('TEXT_RUNNING_TEST_CSP_ONLY'))

--- a/tests/page_not_found.py
+++ b/tests/page_not_found.py
@@ -39,7 +39,7 @@ def change_url_to_404_url(url):
     return url2
 
 
-def run_test(global_translation, lang_code, org_url):
+def run_test(global_translation, org_url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
@@ -47,7 +47,7 @@ def run_test(global_translation, lang_code, org_url):
     rating = Rating(global_translation)
     result_dict = {}
 
-    local_translation = get_translation('page_not_found', lang_code)
+    local_translation = get_translation('page_not_found', get_config('general.language'))
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/performance_lighthouse.py
+++ b/tests/performance_lighthouse.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
+from helpers.setting_helper import get_config
 from tests.lighthouse_base import run_test as lighthouse_base_run_test, get_lighthouse_translations
 
 # DEFAULTS
 STRATEGY = 'mobile'
 CATEGORY = 'performance'
 
-def run_test(global_translation, lang_code, url, silance=False):
+def run_test(global_translation, url, silance=False):
     """
     Analyzes URL with Lighthouse Performance.
     """
 
     translations = get_lighthouse_translations('performance_lighthouse',
-                                               lang_code, global_translation)
+                                               get_config('general.language'),
+                                               global_translation)
     # pylint: disable=duplicate-code
     return lighthouse_base_run_test(
         url,

--- a/tests/performance_sitespeed_io.py
+++ b/tests/performance_sitespeed_io.py
@@ -50,7 +50,7 @@ def get_result(arg):
     return result
 
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Checking an URL against Sitespeed.io (Docker version). 
     For installation, check out:
@@ -58,7 +58,10 @@ def run_test(global_translation, lang_code, url):
     - https://www.sitespeed.io
     """
 
-    local_translation = get_translation('performance_sitespeed_io', lang_code)
+    local_translation = get_translation(
+            'performance_sitespeed_io',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/privacy_webbkollen.py
+++ b/tests/privacy_webbkollen.py
@@ -12,7 +12,7 @@ from helpers.setting_helper import get_config
 # DEFAULTS
 REGEX_ALLOWED_CHARS = r"[^\u00E5\u00E4\u00F6\u00C5\u00C4\u00D6a-zA-Zå-öÅ-Ö 0-9\-:\/]+"
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     This function runs a webbkollen (privacy) test on a given URL and
     returns a rating and a dictionary.
@@ -24,7 +24,6 @@ def run_test(global_translation, lang_code, url):
 
     Parameters:
     global_translation (function): A function to translate text to a global language.
-    lang_code (str): The language code for the local translation.
     url (str): The URL to be tested.
 
     Returns:
@@ -36,7 +35,7 @@ def run_test(global_translation, lang_code, url):
     return_dict = {}
     rating = Rating(global_translation, get_config('general.review.improve-only'))
 
-    local_translation = get_translation('privacy_webbkollen', lang_code)
+    local_translation = get_translation('privacy_webbkollen', get_config('general.language'))
 
     print(local_translation('TEXT_RUNNING_TEST'))
 
@@ -44,7 +43,7 @@ def run_test(global_translation, lang_code, url):
         datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
 
     # Get result from webbkollen website
-    html_content = get_html_content(url, lang_code, local_translation)
+    html_content = get_html_content(url, get_config('general.language'), local_translation)
     soup2 = BeautifulSoup(html_content, 'html.parser')
 
     results = soup2.find_all(class_="result")

--- a/tests/seo_lighthouse.py
+++ b/tests/seo_lighthouse.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
+from helpers.setting_helper import get_config
 from tests.lighthouse_base import run_test as lighthouse_base_run_test, get_lighthouse_translations
 
-def run_test(global_translation, lang_code, url, strategy='mobile', category='seo'):
+def run_test(global_translation, url, strategy='mobile', category='seo'):
     """
     Analyzes URL with Lighthouse SEO.
     """
 
-    translations = get_lighthouse_translations('seo_lighthouse', lang_code, global_translation)
+    translations = get_lighthouse_translations(
+        'seo_lighthouse',
+        get_config('general.language'),
+        global_translation)
     # pylint: disable=duplicate-code
     return lighthouse_base_run_test(
         url,

--- a/tests/software.py
+++ b/tests/software.py
@@ -1604,7 +1604,7 @@ def get_rules():
         rules = json.load(json_rules_file)
     return rules
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
@@ -1612,7 +1612,10 @@ def run_test(global_translation, lang_code, url):
     result_dict = {}
     rating = Rating(global_translation, get_config('general.review.improve-only'))
 
-    local_translation = get_translation('software', lang_code)
+    local_translation = get_translation(
+            'software',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/standard_files.py
+++ b/tests/standard_files.py
@@ -17,7 +17,7 @@ KNOWN_EXTENSIONS = ['bmp', 'css', 'doc', 'docx', 'dot', 'eot', 'exe', 'git',
                     'txt', 'unknown-in-download', 'webp', 'wmv', 'xls', 'xlsx', 'xml', 'zip']
 
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Looking for:
     * robots.txt
@@ -25,7 +25,7 @@ def run_test(global_translation, lang_code, url):
     * a RSS feed mentioned in the page's meta
     """
 
-    local_translation = get_translation('standard_files', lang_code)
+    local_translation = get_translation('standard_files', get_config('general.language'))
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/tests/tracking_validator.py
+++ b/tests/tracking_validator.py
@@ -810,7 +810,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
 
     return rating
 
-def run_test(global_translation, lang_code, url):
+def run_test(global_translation, url):
     """
     Only work on a domain-level. Returns tuple with decimal for grade and string with review
     """
@@ -818,7 +818,10 @@ def run_test(global_translation, lang_code, url):
     result_dict = {}
     rating = Rating(global_translation, get_config('general.review.improve-only'))
 
-    local_translation = get_translation('tracking_validator', lang_code)
+    local_translation = get_translation(
+            'tracking_validator',
+            get_config('general.language')
+        )
 
     print(local_translation('TEXT_RUNNING_TEST'))
 

--- a/utils.py
+++ b/utils.py
@@ -61,15 +61,13 @@ TEST_FUNCS = {
 
 CONFIG_WARNINGS = {}
 
-def test(global_translation, lang_code, site, test_type=None):
+def test(global_translation, site, test_type=None):
     """
     This function runs a specific test on a website and returns the test results.
 
     Parameters:
     global_translation : GNUTranslations
         An object that handles the translation of text in the context of internationalization.
-    lang_code : str
-        The language code for the website to be tested.
     site : tuple
         A tuple containing the site ID and the website URL.
     test_type : str, optional
@@ -91,7 +89,7 @@ def test(global_translation, lang_code, site, test_type=None):
             return []
 
         run_test = TEST_FUNCS[test_type]
-        the_test_result = run_test(global_translation, lang_code, site[1])
+        the_test_result = run_test(global_translation, site[1])
 
         if the_test_result is not None:
             rating = the_test_result[0]
@@ -123,7 +121,7 @@ def test(global_translation, lang_code, site, test_type=None):
     except Exception as ex: # pylint: disable=broad-exception-caught
         print(global_translation('TEXT_TEST_END').format(
             datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
-        info = get_error_info(site[1], lang_code, test_type, ex)
+        info = get_error_info(site[1], test_type, ex)
         print('\n'.join(info).replace('\n\n','\n'))
 
         # write error to failure.log file
@@ -140,7 +138,7 @@ def restart_failures_log():
     with open('failures.log', 'w', encoding='utf-8') as outfile:
         outfile.writelines('')
 
-def get_error_info(url, lang_code, test_type, ex):
+def get_error_info(url, test_type, ex):
     """
     Generate error information for diagnostic purposes.
 
@@ -150,7 +148,6 @@ def get_error_info(url, lang_code, test_type, ex):
 
     Args:
         url (str): The URL associated with the error.
-        lang_code (str): The language code.
         test_type (str): The type of test being performed.
         ex (Exception): The exception object.
 
@@ -166,7 +163,6 @@ def get_error_info(url, lang_code, test_type, ex):
             datetime.now().strftime('%Y-%m-%d %H:%M:%S') \
         }",
         f'\nUrl: {url}',
-        f'\nLanguage Code: {lang_code}',
         f'\nTest Type(s): {test_type}',
         '\n###############################################'
         '\n# Used Configuration:'
@@ -222,15 +218,13 @@ def get_versions():
             result.append("\n")
     return result
 
-def test_site(global_translation, lang_code, site, test_types=TEST_ALL):
+def test_site(global_translation, site, test_types=TEST_ALL):
     """
     This function runs a series of tests on a website and returns a list of all the test results.
 
     Parameters:
     global_translation : GNUTranslations
         An object that handles the translation of text in the context of internationalization.
-    lang_code : str
-        The language code for the website to be tested.
     site : tuple
         A tuple containing the site ID and the website URL.
     test_types : list, optional
@@ -245,14 +239,13 @@ def test_site(global_translation, lang_code, site, test_types=TEST_ALL):
     for test_id in TEST_ALL:
         if test_id in test_types:
             tests.extend(test(global_translation,
-                            lang_code,
                             site,
                             test_type=test_id))
 
     return tests
 
 
-def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL):
+def test_sites(global_translation, sites, test_types=TEST_ALL):
     """
     This function runs a series of tests on multiple websites and
     returns a list of all the test results.
@@ -260,8 +253,6 @@ def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL):
     Parameters:
     global_translation : GNUTranslations
         An object that handles the translation of text in the context of internationalization.
-    lang_code : str
-        The language code for the websites to be tested.
     sites : list
         A list of tuples, each containing the site ID and the website URL.
     test_types : list, optional
@@ -289,7 +280,7 @@ def test_sites(global_translation, lang_code, sites, test_types=TEST_ALL):
         print(global_translation('TEXT_TESTING_SITE').format(website))
         if has_more_then_one_site:
             print(global_translation('TEXT_WEBSITE_X_OF_Y').format(site_index + 1, nof_sites))
-        results.extend(test_site(global_translation, lang_code, site,
+        results.extend(test_site(global_translation, site,
                                  test_types))
 
         site_index += 1


### PR DESCRIPTION
Today when running webperf-core you can specify language to use by using `-L <lang-code>` or `--language <lang-code>` for current run.

In this PR we make it possible to specify it in `settings.json` and have it persistent between runs:

```json
{
    "general": {
        "language": "sv"
    }
}
```

You can also use the longer form for use during current run:
`python default.py --setting general.language=sv -i sites.json`