### PR TITLE
Easier to know what value to use for --setting

### DIFF
--- a/default.py
+++ b/default.py
@@ -270,8 +270,16 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
         """
         print()
         print('Valid settings:')
-        for aliases in config_mapping:
-            print(f"--setting {aliases[1]}=<value> ( alias: {aliases[0]} )")
+        for aliases, value in config_mapping.items():
+            value_type = value.split('|', maxsplit=1)[0]
+            value_desc = 'value'
+            if 'bool' in value_type:
+                value_desc = 'true/false'
+            elif 'int' in value_type:
+                value_desc = 'number'
+            elif 'string' in value_type:
+                value_desc = 'string value'
+            print(f"--setting {aliases[1]}=<{value_desc}> ( alias: {aliases[0]} )")
         print()
 
     def set_setting(self, arg):


### PR DESCRIPTION
Previously we only wrote:
`--setting tests.email.support.port25=<value>`

After this PR we will let user know what type of value we expect (so they don't need to go to documentation as often).

`--setting tests.email.support.port25=<true/false>`

![image](https://github.com/Webperf-se/webperf_core/assets/62792609/dcc15f3f-9b6d-4e6b-a819-1ca5fd5250fc)
