### PR TITLE
Lets test lowering sitespeed default timeout to 30 seconds

### DIFF
--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -40,7 +40,7 @@
             "docker": {
                 "use": false
             },
-            "timeout": 300,
+            "timeout": 30,
             "iterations": 2
         },
         "software": {


### PR DESCRIPTION
from 300 seconds.
Remember you can change this for a single run using `--setting` or more permanent by creating your own `settings.json` file.
Lowering this value could greatly improve time spent in sitespeed based tests.