### PR TITLE
GitHub Actions - Manually start test for provided url and test number

### DIFF
--- a/.github/workflows/manual-start-test.yml
+++ b/.github/workflows/manual-start-test.yml
@@ -2,17 +2,17 @@ name: "Manual - Run test against url"
 on:
   workflow_dispatch:
     inputs:
-      my_url:
+      url:
         description: 'Webpage url to test'
         required: true
         default: 'https://webperf.se/'
         type: string
-      my_test:
+      test:
         description: 'Test to run, comma separated list of numbers'
         required: true
         default: 'true'
         type: string
-      my_details:
+      details:
         description: 'Setting general.review.details'
         required: true
         default: 'true'
@@ -35,7 +35,7 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ env.TEST_TAG }}
-    - name: Test ${{ github.event.inputs.my_test }} for ${{ github.event.inputs.my_url }}
+    - name: Run Test for url
       run: |
-        testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t ${{ github.event.inputs.my_test }} -r -s ${{ github.event.inputs.my_details }} -u ${{ github.event.inputs.my_url }})
+        testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t ${{ github.event.inputs.test }} -r -s ${{ github.event.inputs.details }} -u ${{ github.event.inputs.url }})
         echo "$testresult"

--- a/.github/workflows/manual-start-test.yml
+++ b/.github/workflows/manual-start-test.yml
@@ -17,6 +17,8 @@ on:
         required: true
         default: 'true'
         type: string
+env:
+  TEST_TAG: webperfse/webperf-core:test
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-start-test.yml
+++ b/.github/workflows/manual-start-test.yml
@@ -35,7 +35,7 @@ jobs:
         platforms: linux/amd64
         load: true
         tags: ${{ env.TEST_TAG }}
-    - name: Run Test for url
+    - name: Test ${{ github.event.inputs.test }} for ${{ github.event.inputs.url }}
       run: |
         testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t ${{ github.event.inputs.test }} -r -s ${{ github.event.inputs.details }} -u ${{ github.event.inputs.url }})
         echo "$testresult"

--- a/.github/workflows/manual-start-test.yml
+++ b/.github/workflows/manual-start-test.yml
@@ -1,0 +1,39 @@
+name: "Manual - Run test against url"
+on:
+  workflow_dispatch:
+    inputs:
+      my_url:
+        description: 'Webpage url to test'
+        required: true
+        default: 'https://webperf.se/'
+        type: string
+      my_test:
+        description: 'Test to run, comma separated list of numbers'
+        required: true
+        default: 'true'
+        type: string
+      my_details:
+        description: 'Setting general.review.details'
+        required: true
+        default: 'true'
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup QEMU # used to allow multiplatform docker builds
+      uses: docker/setup-qemu-action@v3
+    - name: Setup Docker Buildx # used to allow multiplatform docker builds
+      uses: docker/setup-buildx-action@v3
+    - name: Build the Docker image # used to allow multiplatform docker builds
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64
+        load: true
+        tags: ${{ env.TEST_TAG }}
+    - name: Test ${{ github.event.inputs.my_test }} for ${{ github.event.inputs.my_url }}
+      run: |
+        testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t ${{ github.event.inputs.my_test }} -r -s ${{ github.event.inputs.my_details }} -u ${{ github.event.inputs.my_url }})
+        echo "$testresult"


### PR DESCRIPTION
New GitHub Action that you can specify url and test number for manually is: Manual - Run test against url