### PR TITLE
Don't install development dependencies for npm

### DIFF
--- a/.github/workflows/regression-test-css.yml
+++ b/.github/workflows/regression-test-css.yml
@@ -49,7 +49,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-google-lighthouse-based.yml
+++ b/.github/workflows/regression-test-google-lighthouse-based.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         node-version: '20.x'
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-html.yml
+++ b/.github/workflows/regression-test-html.yml
@@ -49,7 +49,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-http.yml
+++ b/.github/workflows/regression-test-http.yml
@@ -47,7 +47,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-pa11y.yml
+++ b/.github/workflows/regression-test-pa11y.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         node-version: '20.x'
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     # Havn't yet been able to start Google Chrome in headless mode in pa11y since move to Chrome in Pa11y 5
     - if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: RUNNING TEST - LINUX

--- a/.github/workflows/regression-test-sitespeed.yml
+++ b/.github/workflows/regression-test-sitespeed.yml
@@ -63,7 +63,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-software.yml
+++ b/.github/workflows/regression-test-software.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-tracking.yml
+++ b/.github/workflows/regression-test-tracking.yml
@@ -99,7 +99,7 @@ jobs:
       name: Setup GeckoDriver (Used for Selenium)
       run: wget -q -O - https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz | tar -xvzf -
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-ylt.yml
+++ b/.github/workflows/regression-test-ylt.yml
@@ -39,7 +39,7 @@ jobs:
       run: sudo apt-get install libjpeg-dev libfontconfig
       shell: bash
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/update-software.yml
+++ b/.github/workflows/update-software.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get --only-upgrade install google-chrome-stable
         google-chrome --version
     - name: Setup npm packages
-      run: npm install
+      run: npm install --production
     - name: Update USER_AGENT in our defaults/settings.json
       run: python update_software.py -b
     - name: Checkout advisory-database repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,7 @@ RUN chown --recursive sitespeedio:sitespeedio /usr/src/runner
 # Run everything after as non-privileged user.
 USER sitespeedio
 
-RUN npm install
-
-WORKDIR /usr/src/runner/node_modules/sitespeed.io/
-
-RUN npm install
-
-WORKDIR /usr/src/runner
+RUN npm install --production
 
 RUN python3.12 -m pip install -r requirements.txt --break-system-packages && \
     python3.12 -m pip install --upgrade pip --break-system-packages && \

--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -13,7 +13,7 @@ it is also best/fastest when wanting to contribute with new tests, translations 
 - Download and install Node.js (version 20.x)
 - Download and install Google Chrome browser
 * Download and install Mozilla Firefox
-- Install required npm packages by typing following and hit Enter: `npm install`
+- Install required npm packages by typing following and hit Enter: `npm install --production`
 - Validate that core functionality is working by typing following and hit Enter `python default.py -h`
 - If the output looks something like example in [options and arguments](getting-started.md#options-and-arguments) you have successfully setup the general parts of webperf-core.
 - Please look at/return to the [specific test](tests/README.md) you want to run to make sure it doesn't require more steps.

--- a/docs/tests/css.md
+++ b/docs/tests/css.md
@@ -53,7 +53,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 ##### Windows Specific

--- a/docs/tests/google-lighthouse-based.md
+++ b/docs/tests/google-lighthouse-based.md
@@ -35,7 +35,7 @@ Follow the instructions below depending on what you choose.
 Benefit of this option is that you can use it to test pre production urls like your AcceptanceTest environment.
 
 * Download and install Node.js (version 20.x)
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 
 ## Read more
 

--- a/docs/tests/html.md
+++ b/docs/tests/html.md
@@ -43,7 +43,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 ##### Windows Specific

--- a/docs/tests/http.md
+++ b/docs/tests/http.md
@@ -71,7 +71,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
 * Download and install Mozilla Firefox browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 ##### Windows Specific

--- a/docs/tests/pa11y.md
+++ b/docs/tests/pa11y.md
@@ -44,7 +44,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Follow [general local setup steps for this repository](../getting-started-local.md)
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 
 ## FAQ
 

--- a/docs/tests/sitespeed.md
+++ b/docs/tests/sitespeed.md
@@ -73,7 +73,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Install ffmpeg `sudo apt install ffmpeg`
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 (You can always see [GitHub Actions SiteSpeed](../../.github/workflows/regression-test-sitespeed.yml) for all steps required line by line)
@@ -86,7 +86,7 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Download and Install ffmpeg `https://ffmpeg.org/download.html#build-windows`
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 #### Using Docker image

--- a/docs/tests/software.md
+++ b/docs/tests/software.md
@@ -140,7 +140,7 @@ TODO: Add links to blogs and articles showing how to remove info regarding what 
 
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 ##### Windows Specific

--- a/docs/tests/tracking.md
+++ b/docs/tests/tracking.md
@@ -143,7 +143,7 @@ This section has not been written yet.
 * Download and install Node.js (version 20.x)
 * Download and install Google Chrome browser
 * Download and install Mozilla Firefox
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 * Set `sitespeed_use_docker = False` in your `config.py`
 
 ##### Windows Specific

--- a/docs/tests/yellowlab.md
+++ b/docs/tests/yellowlab.md
@@ -32,11 +32,11 @@ Read more on the [general page for github actions](../getting-started-github-act
 * Download and install Node.js (version 20.x)
 * Download and install node-gyp `npm install -g node-gyp`
 * Setup libjpeg and fontconfig `sudo apt-get install libjpeg-dev libfontconfig`
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 
 ##### On Windows:
 * Download and install Node.js (version 20.x)
-* Install NPM packages ( `npm install` )
+* Install NPM packages ( `npm install --production` )
 
 ## FAQ
 


### PR DESCRIPTION
As we are not modifying or developing any of our npm dependencies,
we may use production mode so devDependencies are not downloaded and installed.
This should lower the amount of time taking to install dependencies but hopefully also number of security related issues.