### PR TITLE
software.py missing is_found default value

### DIFF
--- a/tests/software.py
+++ b/tests/software.py
@@ -1560,6 +1560,9 @@ def apply_rule_results_on_response_header(
         item, rule, req_url,
         hostname, match,
         match_name, match_version):
+    
+    is_found = False
+
     for result in rule['results']:
         name = None
         version = None


### PR DESCRIPTION
### Description
`is_found` bool value were only set `if precision > 0.0`

Changed to default to False