### PR TITLE
Improve CSP Recommendation to allow for sha256 generation of binary content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM sitespeedio/sitespeed.io:34.11.1
 
 USER root
 
-ENV WEBPERF_RUNNER docker
+ENV WEBPERF_RUNNER=docker
 
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
@@ -10,9 +10,9 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 ENV PATH="/usr/local/bin:${PATH}"
 
 # https://codereview.stackexchange.com/a/286565
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&\
     apt-get install -y --no-install-recommends curl gcc g++ gnupg unixodbc-dev openssl git default-jre default-jdk && \

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -117,6 +117,38 @@ Tells email test if it should do a operation over ipv6 also in email test (GitHu
 
 Tells HTTP test to ignore everything except the CSP subtest in the HTTP test (great if you run it against sitemap to get CSP recommendation)
 
+### tests.http.csp-generate-hashes `(Default = false)`
+
+Tells HTTP test to download resources one more time after visiting website to generate sha256 hashes
+for as many resources as possible. (great if you want to have a fast list of sha256 hashed you can use)
+This result in a different CSP recommendation than default as default CSP recommendation only takes in consider text based resources.
+
+### tests.http.csp-generate-strict-recommended-hashes `(Default = false)`
+
+Tells HTTP test to download resources one more time after visiting website to generate sha256 hashes
+for resource types commonly not as content dependent. (great if you run it against sitemap to get CSP recommendation)
+This result in a different CSP recommendation than default as default CSP recommendation only takes in consider text based resources.
+
+### tests.http.csp-generate-css-hashes `(Default = false)`
+
+Tells HTTP test to only download css resources one more time after visiting website to generate sha256 hashes.
+Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.
+
+### tests.http.csp-generate-font-hashes `(Default = false)`
+
+Tells HTTP test to only download font resources one more time after visiting website to generate sha256 hashes.
+Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.
+
+### tests.http.csp-generate-img-hashes `(Default = false)`
+
+Tells HTTP test to only download image resources one more time after visiting website to generate sha256 hashes.
+Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.
+
+### tests.http.csp-generate-js-hashes `(Default = false)`
+
+Tells HTTP test to only download javascript resources one more time after visiting website to generate sha256 hashes.
+Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.
+
 ### tests.lighthouse.disable-sandbox `(Default = false)`
 
 This variable tells lighthouse based test(s) to disable chrome sandbox or not.

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -80,6 +80,18 @@ config_mapping = {
         "csp_only",
         "CSP_ONLY"): "bool|tests.http.csp-only",
     (
+        "csp-generate-hashes",
+        "tests.http.csp-generate-hashes"): "bool|tests.http.csp-generate-hashes",
+    (
+        "csp-generate-font-hashes",
+        "tests.http.csp-generate-font-hashes"): "bool|tests.http.csp-generate-font-hashes",
+    (
+        "csp-generate-img-hashes",
+        "tests.http.csp-generate-img-hashes"): "bool|tests.http.csp-generate-img-hashes",
+    (
+        "csp-generate-js-hashes",
+        "tests.http.csp-generate-js-hashes"): "bool|tests.http.csp-generate-js-hashes",
+    (
         "stealth",
         "tests.software.stealth.use",
         "software_use_stealth",

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -83,6 +83,9 @@ config_mapping = {
         "csp-generate-hashes",
         "tests.http.csp-generate-hashes"): "bool|tests.http.csp-generate-hashes",
     (
+        "csp-generate-strict-recommended-hashes",
+        "tests.http.csp-generate-strict-recommended-hashes"): "bool|tests.http.csp-generate-strict-recommended-hashes",
+    (
         "csp-generate-font-hashes",
         "tests.http.csp-generate-font-hashes"): "bool|tests.http.csp-generate-font-hashes",
     (


### PR DESCRIPTION
Added below settings to help to find out what sha256 hashes to add in your CSP header.
We highly recommend using tests.http.csp-generate-strict-recommended-hashes in your journey to receive 5.0 points for CSP.

### tests.http.csp-generate-hashes `(Default = false)`

Tells HTTP test to download resources one more time after visiting website to generate sha256 hashes
for as many resources as possible. (great if you want to have a fast list of sha256 hashed you can use)
This result in a different CSP recommendation than default as default CSP recommendation only takes in consider text based resources.

### tests.http.csp-generate-strict-recommended-hashes `(Default = false)`

Tells HTTP test to download resources one more time after visiting website to generate sha256 hashes
for resource types commonly not as content dependent. (great if you run it against sitemap to get CSP recommendation)
This result in a different CSP recommendation than default as default CSP recommendation only takes in consider text based resources.

### tests.http.csp-generate-css-hashes `(Default = false)`

Tells HTTP test to only download css resources one more time after visiting website to generate sha256 hashes.
Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.

### tests.http.csp-generate-font-hashes `(Default = false)`

Tells HTTP test to only download font resources one more time after visiting website to generate sha256 hashes.
Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.

### tests.http.csp-generate-img-hashes `(Default = false)`

Tells HTTP test to only download image resources one more time after visiting website to generate sha256 hashes.
Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.

### tests.http.csp-generate-js-hashes `(Default = false)`

Tells HTTP test to only download javascript resources one more time after visiting website to generate sha256 hashes.
Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.