### PR TITLE
Sitespeed workaround for Firefox not including html content

### DIFF
--- a/helpers/csp_helper.py
+++ b/helpers/csp_helper.py
@@ -1413,6 +1413,7 @@ def append_csp_data(req_url, req_domain, res, org_domain, result):
         bool: True if there is a match in the CSP findings, False otherwise.
     """
     csp_findings_match = False
+    # TODO: Remove text empty check when sitespeed has fixed https://github.com/sitespeedio/sitespeed.io/issues/4295
     if 'content' in res and 'text' in res['content'] and res['content']['text'] != '':
         if 'mimeType' in res['content'] and 'text/html' in res['content']['mimeType']:
             csp_findings_match = csp_findings_match or append_csp_data_for_html(


### PR DESCRIPTION
browsertime.har is not including html file content, with this change we will ignore browsertime.har files for some subtests when created by firefox