### PR TITLE
Fix url field for CSS and HTML Test

### DIFF
--- a/tests/w3c_base.py
+++ b/tests/w3c_base.py
@@ -78,6 +78,11 @@ def get_errors(test_type, params):
         if 'messages' in json_result:
             errors = json_result['messages']
 
+    for error in errors:
+        if 'url' in error and get_config('general.cache.use'):
+            error['file'] = error['url']
+        error['url'] = url
+
     return errors
 
 def get_data_for_url(url):


### PR DESCRIPTION
Today the "url" field for every error returned in data object a file path for local file copy of file tested.
This PR changes that, it will now look like this:

```json
{
  "url": "https://example.com/"
}
```

IF you have enabled caching (by setting `general.cache.use` when running test you will also
get a field called "file" that has a path to the cached file on disk we tested against.
