### PR TITLE
Include what urls was tested in CSS Test in Data object

### DIFF
--- a/tests/css_validator_w3c.py
+++ b/tests/css_validator_w3c.py
@@ -46,7 +46,8 @@ def run_test(global_translation, url):
             'style_element': [],
             'style_attribute': [],
             'style_files': []
-        }
+        },
+        'sources': []
     }
 
     for html_entry in data['htmls']:
@@ -58,6 +59,14 @@ def run_test(global_translation, url):
             result_dict)
         rating += tmp_rating
         all_link_resources.extend(tmp_all_link_resources)
+
+    for resource_url in all_link_resources:
+        for entry in data['all']:
+            if resource_url == entry['url']:
+                result_dict['sources'].append({
+                    'url': resource_url,
+                    'index': entry['index']
+                })
 
     # 4 Check if website inlcuded css files in other ways
     for link_resource in all_link_resources:
@@ -123,8 +132,10 @@ def handle_html_markup_entry(entry, global_translation, url, local_translation, 
                 local_translation,
                 f'- `style=""` in: {name}')
 
-        # 2.3 GET ERRORS FROM SERVICE
-        # 2.4 CALCULATE SCORE
+    if 'has_style_elements' in result_dict or\
+            'has_style_attributes' in result_dict:
+        all_link_resources.append(req_url)
+
         # 3 FIND ALL <LINK> (rel=\"stylesheet\")
     (link_resources, errors) = get_errors_for_link_tags(html, url)
     if len(link_resources) > 0:

--- a/tests/w3c_base.py
+++ b/tests/w3c_base.py
@@ -151,6 +151,7 @@ def identify_files(filename):
     """
 
     data = {
+        'all': [],
         'htmls': [],
         'elements': [],
         'attributes': [],
@@ -187,22 +188,26 @@ def identify_files(filename):
                         True,
                         timedelta(minutes=get_config('general.cache.max-age'))):
                     set_cache_file(req_url, res['content']['text'], True)
-                data['htmls'].append({
+                obj = {
                     'url': req_url,
                     'content': res['content']['text'],
                     'index': req_index
-                    })
+                    }
+                data['all'].append(obj)
+                data['htmls'].append(obj)
             elif 'css' in res['content']['mimeType']:
                 if not has_cache_file(
                         req_url,
                         True,
                         timedelta(minutes=get_config('general.cache.max-age'))):
                     set_cache_file(req_url, res['content']['text'], True)
-                data['resources'].append({
+                obj = {
                     'url': req_url,
                     'content': res['content']['text'],
                     'index': req_index
-                    })
+                    }
+                data['all'].append(obj)
+                data['resources'].append(obj)
             req_index += 1
 
     return data


### PR DESCRIPTION
In CSS Test previously it was only clear what urls was tested when/if you got any errors on it (as it would appear in "url" field of the error (in data object).

But if you where good enough to not have any errors you got no feedback and was also unable to know if it was because of errors in test.

```json
{
   "sources": [
      {
         "url": "https://www.example.com/",
         "index": 1
      }
   ]
}
```