### PR TITLE
Bump Python 3.12 to 3.13

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/regression-test-404.yml
+++ b/.github/workflows/regression-test-404.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-a11y-statement.yml
+++ b/.github/workflows/regression-test-a11y-statement.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-css.yml
+++ b/.github/workflows/regression-test-css.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-docker-image.yml
+++ b/.github/workflows/regression-test-docker-image.yml
@@ -86,6 +86,10 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 1 -r -i sites.json)
           echo "$testresult"
         fi
+        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+          echo "Error: WebPerf-core testresult is NOT returning expected review"
+          exit 1
+        fi
         if [[ "$testresult" != *"Performance:"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
@@ -114,6 +118,10 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 4 -r -i sites.json)
           echo "$testresult"
         fi
+        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+          echo "Error: WebPerf-core testresult is NOT returning expected review"
+          exit 1
+        fi
         if [[ "$testresult" != *"Standards:"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
@@ -132,6 +140,10 @@ jobs:
           sleep 5
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 5 -r -i sites.json)
           echo "$testresult"
+        fi
+        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+          echo "Error: WebPerf-core testresult is NOT returning expected review"
+          exit 1
         fi
         if [[ "$testresult" != *"Integrity & Security:"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
@@ -178,6 +190,10 @@ jobs:
           sleep 5
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 10 -r -i sites.json)
           echo "$testresult"
+        fi
+        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+          echo "Error: WebPerf-core testresult is NOT returning expected review"
+          exit 1
         fi
         if [[ "$testresult" != *"A11y:"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
@@ -242,6 +258,10 @@ jobs:
           sleep 5
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 22 -r -i sites.json)
           echo "$testresult"
+        fi
+        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+          echo "Error: WebPerf-core testresult is NOT returning expected review"
+          exit 1
         fi
         if [[ "$testresult" != *"Overall:"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"

--- a/.github/workflows/regression-test-docker-image.yml
+++ b/.github/workflows/regression-test-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 1 -r -i sites.json)
           echo "$testresult"
         fi
-        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+        if [[ "$testresult" == *"Error, was unable to load the page you requested"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
         fi
@@ -118,7 +118,7 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 4 -r -i sites.json)
           echo "$testresult"
         fi
-        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+        if [[ "$testresult" == *"Error, was unable to load the page you requested"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
         fi
@@ -141,7 +141,7 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 5 -r -i sites.json)
           echo "$testresult"
         fi
-        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+        if [[ "$testresult" == *"Error, was unable to load the page you requested"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
         fi
@@ -191,7 +191,7 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 10 -r -i sites.json)
           echo "$testresult"
         fi
-        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+        if [[ "$testresult" == *"Error, was unable to load the page you requested"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
         fi
@@ -259,7 +259,7 @@ jobs:
           testresult=$(docker run ${{ env.TEST_TAG }} python default.py -t 22 -r -i sites.json)
           echo "$testresult"
         fi
-        if [[ "$testresult" == *"Runtime error encountered"* ]]; then
+        if [[ "$testresult" == *"Error, was unable to load the page you requested"* ]]; then
           echo "Error: WebPerf-core testresult is NOT returning expected review"
           exit 1
         fi

--- a/.github/workflows/regression-test-docker-image.yml
+++ b/.github/workflows/regression-test-docker-image.yml
@@ -35,8 +35,8 @@ jobs:
       run: |
         version=$(docker run ${{ env.TEST_TAG }} python --version)
         echo "Python version: $version"
-        if [[ "$version" != "Python 3.12"* ]]; then
-          echo "Error: Default python version is not 3.12 based, was we unable to change default version?"
+        if [[ "$version" != "Python 3.13"* ]]; then
+          echo "Error: Default python version is not 3.13 based, was we unable to change default version?"
           exit 1
         fi
     - name: Check if webperf_core help command works

--- a/.github/workflows/regression-test-email.yml
+++ b/.github/workflows/regression-test-email.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-google-lighthouse-based.yml
+++ b/.github/workflows/regression-test-google-lighthouse-based.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-html.yml
+++ b/.github/workflows/regression-test-html.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-http.yml
+++ b/.github/workflows/regression-test-http.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-pa11y.yml
+++ b/.github/workflows/regression-test-pa11y.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-sitespeed.yml
+++ b/.github/workflows/regression-test-sitespeed.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-software.yml
+++ b/.github/workflows/regression-test-software.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-standard-files.yml
+++ b/.github/workflows/regression-test-standard-files.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-tracking.yml
+++ b/.github/workflows/regression-test-tracking.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-translations.yml
+++ b/.github/workflows/regression-test-translations.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-webbkoll.yml
+++ b/.github/workflows/regression-test-webbkoll.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/regression-test-ylt.yml
+++ b/.github/workflows/regression-test-ylt.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/.github/workflows/update-software.yml
+++ b/.github/workflows/update-software.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '3.13' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: Setup dependencies using pip
       run: pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 3
 
 RUN update-alternatives --config python3
 
-# RUN apt install -y python3.13-distutils
-
 RUN wget https://bootstrap.pypa.io/get-pip.py
 
 RUN python3.13 get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,19 +26,19 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y
 
 RUN apt update
 
-RUN apt install -y python3.12 python3.12-venv
+RUN apt install -y python3.13 python3.13-venv
 
 RUN apt install -y python3-pip
 
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 311
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 311
 
 RUN update-alternatives --config python3
 
-RUN apt install -y python3.12-distutils
+RUN apt install -y python3.13-distutils
 
 RUN wget https://bootstrap.pypa.io/get-pip.py
 
-RUN python3.12 get-pip.py
+RUN python3.13 get-pip.py
 
 RUN apt -y autoremove
 
@@ -64,13 +64,13 @@ USER sitespeedio
 
 RUN npm install --omit=dev
 
-RUN python3.12 -m pip install -r requirements.txt --break-system-packages && \
-    python3.12 -m pip install --upgrade pip --break-system-packages && \
-    python3.12 -m pip install --upgrade setuptools --break-system-packages && \
-    python3.12 -m pip install pyssim Pillow image --break-system-packages
+RUN python3.13 -m pip install -r requirements.txt --break-system-packages && \
+    python3.13 -m pip install --upgrade pip --break-system-packages && \
+    python3.13 -m pip install --upgrade setuptools --break-system-packages && \
+    python3.13 -m pip install pyssim Pillow image --break-system-packages
 
-RUN python3.12 default.py --setting tests.lighthouse.disable-sandbox=true --setting tests.sitespeed.xvfb=true --save-setting settings.json
+RUN python3.13 default.py --setting tests.lighthouse.disable-sandbox=true --setting tests.sitespeed.xvfb=true --save-setting settings.json
 
 ENTRYPOINT []
 
-CMD ["python3.12", "default.py -h"]
+CMD ["python3.13", "default.py -h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 3
 
 RUN update-alternatives --config python3
 
-RUN apt install -y python3.13-distutils
+# RUN apt install -y python3.13-distutils
 
 RUN wget https://bootstrap.pypa.io/get-pip.py
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Locate your pygettext.py file:
 ```locate pygettext.py```
 
 It might be as follows:  
-```/Library/Frameworks/Python.framework/Versions/3.8/share/doc/python3.8/examples/Tools/i18n/pygettext.py```
+```/Library/Frameworks/Python.framework/Versions/3.13/share/doc/python3.13/examples/Tools/i18n/pygettext.py```
 
 ### References
 

--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -4,7 +4,7 @@ This method is best if you want to test/verify private websites like acceptance 
 it is also best/fastest when wanting to contribute with new tests, translations or other stuff.
 
 ## How to setup
-- [Download and install Python 3.12 (or later)](https://www.python.org/downloads/) if you don't have it installed already.
+- [Download and install Python 3.13 (or later)](https://www.python.org/downloads/) if you don't have it installed already.
 - [Fork webperf-core repository](https://github.com/Webperf-se/webperf_core/fork?fragment=1) or [download webperf-core](https://github.com/Webperf-se/webperf_core/archive/refs/heads/main.zip) to your machine.
 - Open the Terminal (Macos & Linux) or Command Prompt (Windows).
 - Navigate to where you downloaded (and unpacked) the source code. If you don’t know how to navigate in Terminal/CMD, read the [Windows guide](https://www.digitalcitizen.life/command-prompt-how-use-basic-commands) or [under Step 5 for Mac / Linux](https://computers.tutsplus.com/tutorials/navigating-the-terminal-a-gentle-introduction--mac-3855).

--- a/tools/dependency.py
+++ b/tools/dependency.py
@@ -50,7 +50,7 @@ def check_python():
         return
 
     version = packaging.version.Version(version)
-    repo_version = packaging.version.Version("3.12")
+    repo_version = packaging.version.Version("3.13")
     if version.major is not repo_version.major:
         print('\t- Python:', 'WARNING: wrong major version')
         return


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->
<header class="article-header">
   <h1 class="page-title">Python 3.13.0</h1>
   </header>
    
   <p><strong>Release Date:</strong> Oct. 7, 2024</p>
    
    
   <h1>This is the stable release of Python 3.13.0</h1>
   <p>Python 3.13.0 is the newest major release of the Python programming language, and it contains many new features and optimizations compared to Python 3.12. (Compared to the last release candidate, 3.13.0rc3, 3.13.0 contains two small bug fixes and some documentation and testing changes.)</p>
   <h1>Major new features of the 3.13 series, compared to 3.12</h1>
   <p>Some of the new major new features and changes in Python 3.13 are:</p>
   <h2>New features</h2>
   <ul>
   <li>A <a href="https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter">new and improved interactive interpreter</a>, based on <a href="https://pypy.org">PyPy</a>'s, featuring multi-line editing and color support, as well as colorized <a href="https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages">exception tracebacks</a>.</li>
   <li>An <a href="https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-free-threaded-cpython"><em>experimental</em> free-threaded build mode</a>, which disables the Global Interpreter Lock, allowing threads to run more concurrently. The build mode is available as an experimental feature in the Windows and macOS installers as well.</li>
   <li>A <a href="https://docs.python.org/3.13/whatsnew/3.13.html#an-experimental-just-in-time-jit-compiler">preliminary, <em>experimental</em> JIT</a>, providing the ground work for significant performance improvements.</li>
   <li>The <code>locals()</code> builtin function (and its C equivalent) now has <a href="https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals">well-defined semantics when mutating the returned mapping</a>, which allows debuggers to operate more consistently.</li>
   <li>A modified version of <a href="https://github.com/microsoft/mimalloc">mimalloc</a> is now included, optional but enabled by default if supported by the platform, and required for the free-threaded build mode.</li>
   <li>Docstrings now have <a href="https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes">their leading indentation stripped</a>, reducing memory use and the size of .pyc files. (Most tools handling docstrings already strip leading indentation.)</li>
   <li>The <a href="https://docs.python.org/3.13/library/dbm.html">dbm module</a> has a new <a href="https://docs.python.org/3.13/whatsnew/3.13.html#dbm">dbm.sqlite3 backend</a> that is used by default when creating new files.</li>
   <li>The minimum supported macOS version was changed from 10.9 to <strong>10.13 (High Sierra)</strong>. Older macOS versions will not be supported going forward.</li>
   <li>WASI is now a <a href="https://peps.python.org/pep-0011/#tier-2">Tier 2 supported platform</a>. Emscripten is no longer an <a href="https://peps.python.org/pep-0011/#no-longer-supported-platforms">officially supported platform</a> (but <a href="https://pyodide.org">Pyodide</a> continues to support Emscripten).</li>
   <li>iOS is now a <a href="https://peps.python.org/pep-0730/">Tier 3 supported platform</a>.</li>
   <li>Android is now a <a href="https://peps.python.org/pep-0738/">Tier 3 supported platform</a>.</li>
   </ul>
   <h2>Typing</h2>
   <ul>
   <li>Support for <a href="https://peps.python.org/pep-0696/">type defaults in type parameters</a>.</li>
   <li>A <a href="https://peps.python.org/pep-0742/">new type narrowing annotation</a>, <code>typing.TypeIs</code>.</li>
   <li>A new annotation for <a href="https://peps.python.org/pep-0705/">read-only items in TypeDicts</a>.</li>
   <li>A new annotation for <a href="https://peps.python.org/pep-0702">marking deprecations in the type system</a>.</li>
   </ul>
   <h2>Removals and new deprecations</h2>
   <ul>
   <li><a href="https://peps.python.org/pep-0594/">PEP 594 (Removing dead batteries from the standard library)</a> scheduled removals of many deprecated modules: <code>aifc</code>, <code>audioop</code>, <code>chunk</code>, <code>cgi</code>, <code>cgitb</code>, <code>crypt</code>, <code>imghdr</code>, <code>mailcap</code>, <code>msilib</code>, <code>nis</code>, <code>nntplib</code>, <code>ossaudiodev</code>, <code>pipes</code>, <code>sndhdr</code>, <code>spwd</code>, <code>sunau</code>, <code>telnetlib</code>, <code>uu</code>, <code>xdrlib</code>, <code>lib2to3</code>.</li>
   <li><a href="https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis">Many other removals</a> of deprecated classes, functions and methods in various standard library modules.</li>
   <li>C API <a href="https://docs.python.org/3.13/whatsnew/3.13.html#removed-c-apis">removals</a> and <a href="https://docs.python.org/3.13/whatsnew/3.13.html#deprecated-c-apis">deprecations</a>.  (Some removals present in alpha 1 were reverted in alpha 2, as the removals were deemed too disruptive at this time.)</li>
   <li><a href="https://docs.python.org/3.13/whatsnew/3.13.html#new-deprecations">New deprecations</a>, most of which are scheduled for removal from Python 3.15 or 3.16.</li>
   </ul>
   <p>For more details on the changes to Python 3.13, see <a href="https://docs.python.org/3.13/whatsnew/3.13.html">What's new in Python 3.13</a>.</p>

<!--EndFragment-->
</body>
</html><header class="article-header">
            <h1 class="page-title">Python 3.13.0</h1>
        </header>

        <p><strong>Release Date:</strong> Oct. 7, 2024</p>

        
        <h1>This is the stable release of Python 3.13.0</h1>
<p>Python 3.13.0 is the newest major release of the Python programming language, and it contains many new features and optimizations compared to Python 3.12. (Compared to the last release candidate, 3.13.0rc3, 3.13.0 contains two small bug fixes and some documentation and testing changes.)</p>
<h1>Major new features of the 3.13 series, compared to 3.12</h1>
<p>Some of the new major new features and changes in Python 3.13 are:</p>
<h2>New features</h2>
<ul>
<li>A <a href="https://docs.python.org/3.13/whatsnew/3.13.html#a-better-interactive-interpreter">new and improved interactive interpreter</a>, based on <a href="https://pypy.org/">PyPy</a>'s, featuring multi-line editing and color support, as well as colorized <a href="https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages">exception tracebacks</a>.</li>
<li>An <a href="https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-free-threaded-cpython"><em>experimental</em> free-threaded build mode</a>, which disables the Global Interpreter Lock, allowing threads to run more concurrently. The build mode is available as an experimental feature in the Windows and macOS installers as well.</li>
<li>A <a href="https://docs.python.org/3.13/whatsnew/3.13.html#an-experimental-just-in-time-jit-compiler">preliminary, <em>experimental</em> JIT</a>, providing the ground work for significant performance improvements.</li>
<li>The <code>locals()</code> builtin function (and its C equivalent) now has <a href="https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals">well-defined semantics when mutating the returned mapping</a>, which allows debuggers to operate more consistently.</li>
<li>A modified version of <a href="https://github.com/microsoft/mimalloc">mimalloc</a> is now included, optional but enabled by default if supported by the platform, and required for the free-threaded build mode.</li>
<li>Docstrings now have <a href="https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes">their leading indentation stripped</a>, reducing memory use and the size of .pyc files. (Most tools handling docstrings already strip leading indentation.)</li>
<li>The <a href="https://docs.python.org/3.13/library/dbm.html">dbm module</a> has a new <a href="https://docs.python.org/3.13/whatsnew/3.13.html#dbm">dbm.sqlite3 backend</a> that is used by default when creating new files.</li>
<li>The minimum supported macOS version was changed from 10.9 to <strong>10.13 (High Sierra)</strong>. Older macOS versions will not be supported going forward.</li>
<li>WASI is now a <a href="https://peps.python.org/pep-0011/#tier-2">Tier 2 supported platform</a>. Emscripten is no longer an <a href="https://peps.python.org/pep-0011/#no-longer-supported-platforms">officially supported platform</a> (but <a href="https://pyodide.org/">Pyodide</a> continues to support Emscripten).</li>
<li>iOS is now a <a href="https://peps.python.org/pep-0730/">Tier 3 supported platform</a>.</li>
<li>Android is now a <a href="https://peps.python.org/pep-0738/">Tier 3 supported platform</a>.</li>
</ul>
<h2>Typing</h2>
<ul>
<li>Support for <a href="https://peps.python.org/pep-0696/">type defaults in type parameters</a>.</li>
<li>A <a href="https://peps.python.org/pep-0742/">new type narrowing annotation</a>, <code>typing.TypeIs</code>.</li>
<li>A new annotation for <a href="https://peps.python.org/pep-0705/">read-only items in TypeDicts</a>.</li>
<li>A new annotation for <a href="https://peps.python.org/pep-0702">marking deprecations in the type system</a>.</li>
</ul>
<h2>Removals and new deprecations</h2>
<ul>
<li><a href="https://peps.python.org/pep-0594/">PEP 594 (Removing dead batteries from the standard library)</a> scheduled removals of many deprecated modules: <code>aifc</code>, <code>audioop</code>, <code>chunk</code>, <code>cgi</code>, <code>cgitb</code>, <code>crypt</code>, <code>imghdr</code>, <code>mailcap</code>, <code>msilib</code>, <code>nis</code>, <code>nntplib</code>, <code>ossaudiodev</code>, <code>pipes</code>, <code>sndhdr</code>, <code>spwd</code>, <code>sunau</code>, <code>telnetlib</code>, <code>uu</code>, <code>xdrlib</code>, <code>lib2to3</code>.</li>
<li><a href="https://docs.python.org/3.13/whatsnew/3.13.html#removed-modules-and-apis">Many other removals</a> of deprecated classes, functions and methods in various standard library modules.</li>
<li>C API <a href="https://docs.python.org/3.13/whatsnew/3.13.html#removed-c-apis">removals</a> and <a href="https://docs.python.org/3.13/whatsnew/3.13.html#deprecated-c-apis">deprecations</a>.  (Some removals present in alpha 1 were reverted in alpha 2, as the removals were deemed too disruptive at this time.)</li>
<li><a href="https://docs.python.org/3.13/whatsnew/3.13.html#new-deprecations">New deprecations</a>, most of which are scheduled for removal from Python 3.15 or 3.16.</li>
</ul>
<p>For more details on the changes to Python 3.13, see <a href="https://docs.python.org/3.13/whatsnew/3.13.html">What's new in Python 3.13</a>.</p>