### PR TITLE
Regression Tests, set timeout for NPM Install to 30 minutes

### DIFF
--- a/.github/workflows/regression-test-css.yml
+++ b/.github/workflows/regression-test-css.yml
@@ -50,6 +50,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-google-lighthouse-based.yml
+++ b/.github/workflows/regression-test-google-lighthouse-based.yml
@@ -34,6 +34,7 @@ jobs:
         node-version: '20.x'
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-html.yml
+++ b/.github/workflows/regression-test-html.yml
@@ -50,6 +50,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-http.yml
+++ b/.github/workflows/regression-test-http.yml
@@ -48,6 +48,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-pa11y.yml
+++ b/.github/workflows/regression-test-pa11y.yml
@@ -35,6 +35,7 @@ jobs:
         node-version: '20.x'
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     # Havn't yet been able to start Google Chrome in headless mode in pa11y since move to Chrome in Pa11y 5
     - if: ${{ matrix.os == 'ubuntu-20.04' }}
       name: RUNNING TEST - LINUX

--- a/.github/workflows/regression-test-sitespeed.yml
+++ b/.github/workflows/regression-test-sitespeed.yml
@@ -64,6 +64,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-software.yml
+++ b/.github/workflows/regression-test-software.yml
@@ -45,6 +45,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-tracking.yml
+++ b/.github/workflows/regression-test-tracking.yml
@@ -104,6 +104,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/regression-test-ylt.yml
+++ b/.github/workflows/regression-test-ylt.yml
@@ -34,12 +34,14 @@ jobs:
         node-version: '20.x'
     - name: Setup node dependencies (ONLY used for Yellow Lab Tools)
       run: npm install -g node-gyp
+      timeout-minutes: 30
     - if: matrix.os == 'ubuntu-latest'
       name: Setup libjpeg and fontconfig (ONLY used for Yellow Lab Tools) - LINUX
       run: sudo apt-get install libjpeg-dev libfontconfig
       shell: bash
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |

--- a/.github/workflows/update-software.yml
+++ b/.github/workflows/update-software.yml
@@ -43,6 +43,7 @@ jobs:
         google-chrome --version
     - name: Setup npm packages
       run: npm install --omit=dev
+      timeout-minutes: 30
     - name: Update USER_AGENT in our defaults/settings.json
       run: python default.py --update-browser
     - name: Checkout advisory-database repo


### PR DESCRIPTION
Lets fail faster, instead of waiting 5 hours for a test we know will fail.