### PR TITLE
CSS Test - Don't report use of custom properties as errors

### DIFF
--- a/tests/css_validator_w3c.py
+++ b/tests/css_validator_w3c.py
@@ -638,4 +638,9 @@ def error_has_whitelisted_wording(error_message, whitelisted_words):
         if whitelisted_word in error_message:
             in_whitelisted = True
             break
+
+    property_regex = r"CSS\: “\-\-[^”]+”\: Parse Error\."
+    if re.search(property_regex, error_message, re.MULTILINE) is not None:
+        in_whitelisted = True
+
     return in_whitelisted


### PR DESCRIPTION
We will remove errors that matches below regular expression:
`CSS\: “\-\-[^”]+”\: Parse Error\.`