### PR TITLE
Yellow Lab Tools - Regression Test, revert Ubuntu version to 22.04

### DIFF
--- a/.github/workflows/regression-test-ylt.yml
+++ b/.github/workflows/regression-test-ylt.yml
@@ -51,14 +51,14 @@ jobs:
     - name: Setup node dependencies (ONLY used for Yellow Lab Tools)
       run: npm install -g node-gyp
       timeout-minutes: 30
-    - if: matrix.os == 'ubuntu-latest'
+    - if: matrix.os == 'ubuntu-22.04'
       name: Setup libjpeg and fontconfig (ONLY used for Yellow Lab Tools) - LINUX
       run: sudo apt-get install libjpeg-dev libfontconfig
       shell: bash
     - name: Setup npm packages
       run: npm install --omit=dev
       timeout-minutes: 30
-    - if: ${{ matrix.os == 'ubuntu-latest' }}
+    - if: ${{ matrix.os == 'ubuntu-22.04' }}
       name: RUNNING TEST - LINUX
       run: |
          python default.py -t ${{ matrix.version }} -r -i defaults/sites.json -o data/testresult-${{ matrix.version }}.json

--- a/.github/workflows/regression-test-ylt.yml
+++ b/.github/workflows/regression-test-ylt.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-22.04, windows-latest]
                 version: [17]
     steps:
     - name: Check out repository code


### PR DESCRIPTION
Regression test for YLT has started to fail, only change we know of is that GitHub Actions has upgraded ubuntu-latest to ubuntu-24.04 from 22.04.
So we revert to 22.04.

See: https://github.com/actions/runner-images/issues/10636