### PR TITLE
Lighthouse Based Tests - Output file should include same source as seen in review

### DIFF
--- a/tests/lighthouse_base.py
+++ b/tests/lighthouse_base.py
@@ -222,9 +222,6 @@ def create_rating_from_audits(category, global_translation, json_content, return
     weight_dict = create_weight_dict(category, json_content)
     reviews = []
     for audit_key, item in json_content['audits'].items():
-        if 'numericValue' in item:
-            return_dict[audit_key] = item['numericValue']
-
         if audit_key not in weight_dict:
             continue
 
@@ -232,6 +229,8 @@ def create_rating_from_audits(category, global_translation, json_content, return
         review_item = create_rating_from_audit(item, category, global_translation, weight)
         if review_item is None:
             continue
+
+        return_dict[audit_key] = item
         reviews.append(review_item)
 
     sorted_reviews = sorted(reviews,


### PR DESCRIPTION
Accessibility (Google Lighthouse) didn't include any a11y related in output file, see issue #586.

This PR should fix that BUT it will break the structure of our output file for lighthouse based test.
Previously it only included a key-value pair of audit-name and the corresponding score.
We also only added audits that had numericValue set.

Now we will add ALL audits that we add reviews for.

Please note that the only breaking change is for lighthouse based test and only for if you directly parse the output file.
