### PR TITLE
energy_efficiency.py lacked a default unit value

### DIFF
--- a/tests/energy_efficiency.py
+++ b/tests/energy_efficiency.py
@@ -145,6 +145,7 @@ def format_bytes(size):
         unit = "MB"
     else:
         closest_value = kilobytes_value
+        unit = "KB"
 
     return float(f'{closest_value:.2f}'), unit
 


### PR DESCRIPTION
### Description
Now sets a default unit as "KB" as fallback.

Used to throw exceptions for webpages with smaller files.