### PR TITLE
Sitespeed Based Tests - Added support for mobile

### DIFF
--- a/default.py
+++ b/default.py
@@ -329,6 +329,9 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
         if len(self.test_types) == 0:
             show_test_help(self.language)
 
+    def enable_mobile(self, _):
+        self.set_setting('tests.sitespeed.mobile=true')
+
     def enable_reviews(self, _):
         """
         Enables the display of reviews for the instance.
@@ -465,6 +468,7 @@ class CommandLineOptions: # pylint: disable=too-many-instance-attributes,missing
             ("-t", "--test"): self.set_test_types,
             ("-i", "--input"): self.set_input_handlers,
             ("--is", "--input-skip"): self.set_input_skip,
+            ("-m", "--mobile"): self.enable_mobile,
             ("--it", "--input-take"): self.set_input_take,
             ("-o", "--output"): self.set_output_filename,
             ("-r", "--review", "--report"): self.enable_reviews,
@@ -517,10 +521,11 @@ def main(argv):
     options.load_language(get_config('general.language'))
 
     try:
-        opts, _ = getopt.getopt(argv, "hu:t:i:o:rA:D:L:s:cbd:", [
+        opts, _ = getopt.getopt(argv, "hu:t:i:o:rA:D:L:s:cbd:m", [
                                    "help", "url=", "test=", "input=", "output=",
                                    "review", "report", "addUrl=", "deleteUrl=",
                                    "language=", "input-skip=", "input-take=",
+                                   "mobile",
                                    "credits", "contributors",
                                    "uc" ,"update-credits",
                                    "ums", "update-mdn-sources",

--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -42,6 +42,7 @@
                 "use": false
             },
             "timeout": 30,
+            "mobile": false,
             "iterations": 2,
             "xvfb": false,
             "cache": {

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -177,6 +177,10 @@ Setting this to a lower value may improve overall test speed if many urls are be
 it is not important if one or two tests fail.
 Please read more about this on [SiteSpeed test section](tests/sitespeed.md).
 
+### tests.sitespeed.mobile `(Default = false)`
+
+This variable tells sitespeed based test(s) to simulate mobile browser.
+
 ### tests.sitespeed.xvfb `(Default = false)`
 
 This variable tells sitespeed based test(s) to start xvfb before the browser is started.

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -68,6 +68,9 @@ config_mapping = {
         "sitespeed_use_docker",
         "SITESPEED_USE_DOCKER"): "bool|tests.sitespeed.docker.use",
     (
+        "mobile",
+        "tests.sitespeed.mobile"): "bool|tests.sitespeed.mobile",
+    (
         "sitespeedtimeout",
         "tests.sitespeed.timeout",
         "sitespeed_timeout",

--- a/tests/sitespeed_base.py
+++ b/tests/sitespeed_base.py
@@ -10,7 +10,8 @@ import shutil
 import urllib
 from urllib.parse import ParseResult, urlparse, urlunparse
 import uuid
-from tests.utils import get_dependency_version, is_file_older_than
+from tests.utils import change_url_to_test_url,\
+    get_dependency_version, is_file_older_than
 import engines.sitespeed_result as sitespeed_cache
 from helpers.setting_helper import get_config
 
@@ -59,6 +60,10 @@ def get_result(url, sitespeed_use_docker, sitespeed_arg, timeout):
     hostname = o.hostname
 
     result_folder_name = os.path.join(folder, hostname, f'{str(uuid.uuid4())}')
+
+    if get_config('tests.sitespeed.mobile'):
+        url = change_url_to_test_url(url, 'mobile')
+        sitespeed_arg += (' --mobile')
 
     sitespeed_arg += (' --postScript chrome-cookies.cjs --postScript chrome-versions.cjs '
                       f'--outputFolder {result_folder_name} {url}')


### PR DESCRIPTION
Added new setting to use for sitespeed based tests.
It tells the test to simulate a mobile browser.

Available from settings.json in `tests.sitespeed.mobile`
or in command using `--mobile`.