### PR TITLE
Added support for using custom cache folder

### DIFF
--- a/.github/workflows/regression-test-404.yml
+++ b/.github/workflows/regression-test-404.yml
@@ -65,10 +65,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se/2f08c/finns-det-en-sida/pa-den-har-adressen/testanrop/?webperf-core-test-2 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting tests.page-not-found.override-url=false --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se/2f08c/finns-det-en-sida/pa-den-har-adressen/testanrop/?webperf-core-test-2 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting tests.page-not-found.override-url=false --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se/2f08c/finns-det-en-sida/pa-den-har-adressen/testanrop/?webperf-core-test-2 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.page-not-found.override-url=false --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se/2f08c/finns-det-en-sida/pa-den-har-adressen/testanrop/?webperf-core-test-2 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.page-not-found.override-url=false --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-a11y-statement.yml
+++ b/.github/workflows/regression-test-a11y-statement.yml
@@ -69,10 +69,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://msb.se?webperf-core-test-26 -o data/testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://msb.se?webperf-core-test-26 -o data/testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://msb.se?webperf-core-test-26 -o data\testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://msb.se?webperf-core-test-26 -o data\testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-css.yml
+++ b/.github/workflows/regression-test-css.yml
@@ -71,10 +71,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-7 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-7 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-7 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-7 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-energy-efficiency.yml
+++ b/.github/workflows/regression-test-energy-efficiency.yml
@@ -69,10 +69,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-22 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-22 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-22 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-22 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-google-lighthouse-based.yml
+++ b/.github/workflows/regression-test-google-lighthouse-based.yml
@@ -54,12 +54,12 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-${{ matrix.version }} -o data/testresult-${{ matrix.version }}.json --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-${{ matrix.version }} -o data/testresult-${{ matrix.version }}.json --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-${{ matrix.version }} -o data\testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-${{ matrix.version }} -o data\testresult-${{ matrix.version }}.json --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'ubuntu-latest' && matrix.version == 1 }}
       name: RUNNING TEST - LINUX

--- a/.github/workflows/regression-test-html.yml
+++ b/.github/workflows/regression-test-html.yml
@@ -71,10 +71,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-6 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-6 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-6 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-6 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-http.yml
+++ b/.github/workflows/regression-test-http.yml
@@ -69,10 +69,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-21 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-21 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-21 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-21 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-lint-css.yml
+++ b/.github/workflows/regression-test-lint-css.yml
@@ -71,20 +71,20 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX (no-errors)
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-no-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-no-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS (no-errors)
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-no-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-no-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX (with-errors)
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-with-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-with-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS (with-errors)
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-with-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-27-with-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-software.yml
+++ b/.github/workflows/regression-test-software.yml
@@ -66,10 +66,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-25-no-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-25-no-errors -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-25-no-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-25-no-errors -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/.github/workflows/regression-test-tracking.yml
+++ b/.github/workflows/regression-test-tracking.yml
@@ -125,10 +125,10 @@ jobs:
     - if: ${{ matrix.os == 'ubuntu-latest' }}
       name: RUNNING TEST - LINUX
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-23 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-23 -o data/testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting tests.sitespeed.xvfb=true --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github/workflows/verify_result.py -t ${{ matrix.version }}
     - if: ${{ matrix.os == 'windows-latest' }}
       name: RUNNING TEST - WINDOWS
       run: |
-         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-23 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting tests.sitespeed.cache.folder=unittests
+         python default.py -t ${{ matrix.version }} -r -u https://webperf.se?webperf-core-test-23 -o data\testresult-${{ matrix.version }}.json --setting ${{ matrix.config }} --setting general.cache.use=true --setting general.cache.max-age=5256000 --setting general.cache.folder=unittests
          python .github\workflows\verify_result.py -t ${{ matrix.version }}

--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -16,6 +16,7 @@
         "useragent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0",
         "cache": {
             "use": false,
+            "folder": "cache",
             "max-age": 60
         }
     },
@@ -41,10 +42,7 @@
             "timeout": 30,
             "mobile": false,
             "iterations": 2,
-            "xvfb": false,
-            "cache": {
-                "folder": "cache"
-            }
+            "xvfb": false
         },
         "software": {
             "advisory": {

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -90,6 +90,11 @@ resulting in less requests and strain on the url you are testing.
 
 See `general.cache.max-age` setting to determine how long.
 
+### general.cache.folder `(Default = "cache")`
+This tells webperf-core what foldername to use for cache.
+This take no effect unless `general.cache.use` is set to `true`.
+
+
 ### general.cache.max-age `(Default = 60 minutes)`
 This tells webperf-core how long to use cached resources in minutes.
 This take no effect unless `general.cache.use` is set to `true`.

--- a/engines/sitespeed_result.py
+++ b/engines/sitespeed_result.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 import re
 from engines.utils import use_item
+from helpers.setting_helper import get_config
 
 def get_url_from_file_content(input_filename):
     """
@@ -90,4 +91,5 @@ def read_sites(hostname_or_argument, input_skip, input_take):
     list: A list of sites where each site is represented as a
           list containing the path to the HAR file and the URL.
     """
-    return read_sites_from_directory('cache', hostname_or_argument, input_skip, input_take)
+    cache_folder = get_config('general.cache.folder')
+    return read_sites_from_directory(cache_folder, hostname_or_argument, input_skip, input_take)

--- a/helpers/credits_helper.py
+++ b/helpers/credits_helper.py
@@ -7,6 +7,8 @@ import re
 import urllib
 import urllib.parse
 
+from helpers.setting_helper import get_config
+
 def update_credits_markdown(global_translation):
     creds = get_credits(global_translation)
 
@@ -204,6 +206,7 @@ def get_py_files(base_directory):
     except:
         return py_files
 
+    cache_folder = get_config('general.cache.folder')
     for sub_file_or_dir in sub_files_or_dirs:
         if sub_file_or_dir[0:1] == '.':
             continue
@@ -226,7 +229,8 @@ def get_py_files(base_directory):
                 'node_modules',
                 'LICENSE',
                 'tmp',
-                'locales'):
+                'locales',
+                cache_folder):
             continue
         else:
             sub_py_files = get_py_files( os.path.join(base_directory, sub_file_or_dir) )

--- a/helpers/mdn_helper.py
+++ b/helpers/mdn_helper.py
@@ -1,18 +1,11 @@
 # -*- coding: utf-8 -*-
-import getopt
-import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 import json
 import re
 import os
 from bs4 import BeautifulSoup
 from tests.utils import get_http_content
-from helpers.setting_helper import get_config
-from helpers.test_helper import get_error_info
 
-USE_CACHE = get_config('general.cache.use')
-CACHE_TIME_DELTA = timedelta(minutes=get_config('general.cache.max-age'))
 CONFIG_WARNINGS = {}
 
 def get_mdn_web_docs_css_features():

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -82,7 +82,8 @@ config_mapping = {
         "tests.sitespeed.xvfb"): "bool|tests.sitespeed.xvfb",
     (
         "sitespeedcustomcache",
-        "tests.sitespeed.cache.folder"): "string|tests.sitespeed.cache.folder",
+        "general.cache.folder",
+        "tests.sitespeed.cache.folder"): "string|general.cache.folder",
     (
         "csponly",
         "tests.http.csp-only",

--- a/helpers/update_software_helper.py
+++ b/helpers/update_software_helper.py
@@ -32,7 +32,7 @@ def update_user_agent():
 
     folder = 'tmp'
     if USE_CACHE:
-        folder = 'cache'
+        folder = get_config('general.cache.folder')
 
     url = "https://webperf.se/"
     o = urlparse(url)

--- a/tests/sitespeed_base.py
+++ b/tests/sitespeed_base.py
@@ -54,7 +54,7 @@ def get_result(url, sitespeed_use_docker, sitespeed_arg, timeout):
     """
     folder = 'tmp'
     if get_config('general.cache.use'):
-        folder = 'cache'
+        folder = get_config('general.cache.folder')
 
     o = urlparse(url)
     hostname = o.hostname
@@ -110,13 +110,7 @@ def get_cached_result(url, hostname):
 
     filename = ''
     result_folder_name = ''
-    sites = []
-
-    custom_cache_folder = get_config('tests.sitespeed.cache.folder')
-    if custom_cache_folder:
-        sites = sitespeed_cache.read_sites_from_directory(custom_cache_folder, hostname, -1, -1)
-    else:
-        sites = sitespeed_cache.read_sites(hostname, -1, -1)
+    sites = sitespeed_cache.read_sites(hostname, -1, -1)
 
     for site in sites:
         if url == site[1] or url2 == site[1]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -153,7 +153,7 @@ def get_cache_path_for_rule(url, cache_key_rule):
 
     folder = 'tmp'
     if get_config('general.cache.use'):
-        folder = 'cache'
+        folder = get_config('general.cache.folder')
 
     folder_path = os.path.join(folder)
     if not os.path.exists(folder_path):
@@ -298,10 +298,13 @@ def clean_cache_files():
             shutil.rmtree(base_directory)
         return
     file_ending = '.cache'
-    folder = 'cache'
+    folder = get_config('general.cache.folder')
     base_directory = os.path.join(Path(os.path.dirname(
         os.path.realpath(__file__)) + os.path.sep).parent, folder)
 
+    clean_folder(folder, base_directory, file_ending)
+
+def clean_folder(folder, base_directory, file_ending):
     if not os.path.exists(base_directory):
         return
 


### PR DESCRIPTION
Changed the custom read-only cache version only available for sitespeed based test to
be full read and write and support all cached resources.

Previous you could call:
`--setting tests.sitespeed.cache.folder=unittests`

The call has now changed to:
`--setting general.cache.folder=unittests`

Both where `unittests `are the foldername to use.

Thanks @marcusosterberg for suggesting it.