### PR TITLE
Sitespeed Based Tests - Add support for Edge

### DIFF
--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -39,6 +39,7 @@
             "csp-only": false
         },
         "sitespeed": {
+            "browser": "chrome",
             "docker": {
                 "use": false
             },

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -164,6 +164,18 @@ Please also see csp-generate-strict-recommended-hashes and tests.http.csp-genera
 Tells HTTP test to only download javascript resources one more time after visiting website to generate sha256 hashes.
 Please also see csp-generate-strict-recommended-hashes and tests.http.csp-generate-hashes.
 
+### test.sitespeed.browser `(Default = "chrome")`
+With this setting you can change to use edge as browser for sitespeed based tests.
+For now this is more or less useless for none windows users.
+BUT for windows users, this setting makes it possible use edge instead
+of chrome,
+meaning you don't need to download an extra browser just for testing.
+Valid values are:
+- chrome
+- edge
+NOTE: Firefox is not supported yet because of missing functionality making
+it impossible to collect resource content.
+
 ### tests.sitespeed.docker.use `(Default = false)`
 
 This variable tells sitespeed based test(s) to use docker image version instead of NPM version.
@@ -194,13 +206,6 @@ This is only relevant for linux based os.
 This variable is ONLY used to generate a CVE and security related info for software.
 Tell software update tool the path to where you have repo of: https://github.com/github/advisory-database
 
-### test.software.browser `(Default = "chrome")`
-For now this is more or less useless for none developers.
-In the future the goal is to make it possible to decide what browser to use when running tests.
-Valid values are:
-- chrome
-- firefox
-- edge
 
 ### test.software.stealth.use `(Default = true)`
 Tell software test to use stealth mode or not.

--- a/helpers/browser_helper.py
+++ b/helpers/browser_helper.py
@@ -1,0 +1,7 @@
+from helpers.setting_helper import get_config
+
+def get_chromium_browser():
+    browser = get_config('tests.sitespeed.browser')
+    if browser in ('chrome', 'edge'):
+        return browser
+    return 'chrome'

--- a/helpers/dependency_helper.py
+++ b/helpers/dependency_helper.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import packaging.version
 
 from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 
 def test_cmd(command):
     process_failsafe_timeout = 600
@@ -288,8 +289,8 @@ def check_package():
 
                 print(f"\t\t- {dependency_name}: OK")
 
-def check_chrome():
-    return check_browser('chrome')
+def check_chromium():
+    return check_browser(get_chromium_browser())
 
 def check_firefox():
     return check_browser('firefox')
@@ -321,9 +322,9 @@ def check_browser(browser):
             '--firefox.preference browser.safebrowsing.malware.enabled:false '
             '--firefox.preference browser.safebrowsing.phishing.enabled:false '
             f'{sitespeed_arg}')
-    else:
+    elif browser in ('chrome', 'edge'):
         sitespeed_arg = (
-            '-b chrome '
+            f'-b {browser} '
             '--chrome.cdp.performance false '
             '--browsertime.chrome.timeline false '
             '--browsertime.chrome.includeResponseBodies all '
@@ -365,7 +366,7 @@ def dependency():
     check_node()
     check_package()
     check_java()
-    check_chrome()
+    check_chromium()
     check_firefox()
     # TODO: Check data files dependencies
     # TODO: Check Internet access (for required sources like MDN Web Reference)

--- a/helpers/setting_helper.py
+++ b/helpers/setting_helper.py
@@ -60,6 +60,9 @@ config_mapping = {
         "css_review_group_errors",
         "CSS_REVIEW_GROUP_ERRORS"): "bool|tests.css.group",
     (
+        "browser",
+        "tests.sitespeed.browser"): "string|tests.sitespeed.browser",
+    (
         "sitespeeddocker",
         "tests.sitespeed.docker.use",
         "sitespeed_use_docker",
@@ -115,11 +118,6 @@ config_mapping = {
         "software_github_adadvisory_database_path",
         "SOFTWARE_GITHUB_ADADVISORY_DATABASE_PATH"
     ): "string|tests.software.advisory.path",
-    (
-        "browser",
-        "tests.software.browser",
-        "software_browser",
-        "SOFTWARE_BROWSER"): "string|tests.software.browser",
     (
         "mailport25",
         "tests.email.support.port25",

--- a/helpers/update_software_helper.py
+++ b/helpers/update_software_helper.py
@@ -9,10 +9,11 @@ import time
 from urllib.parse import urlparse
 import uuid
 import packaging.version
+from helpers.setting_helper import get_config, update_config
+from helpers.browser_helper import get_chromium_browser
 from tests.sitespeed_base import get_browsertime_har_path,\
     get_result_using_no_cache, get_sanitized_browsertime
 from tests.utils import get_http_content
-from helpers.setting_helper import get_config, update_config
 
 USE_CACHE = get_config('general.cache.use')
 CACHE_TIME_DELTA = timedelta(minutes=get_config('general.cache.max-age'))
@@ -68,7 +69,7 @@ def update_user_agent():
             f'{sitespeed_arg}')
     else:
         sitespeed_arg = (
-            '-b chrome '
+            f'-b {get_chromium_browser()} '
             '--chrome.cdp.performance false '
             '--browsertime.chrome.timeline false '
             '--browsertime.chrome.includeResponseBodies all '

--- a/tests/a11y_statement.py
+++ b/tests/a11y_statement.py
@@ -8,6 +8,7 @@ import urllib.parse
 from bs4 import BeautifulSoup
 from helpers.models import Rating
 from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 from tests.sitespeed_base import get_result
 from tests.utils import get_http_content, get_translation
 
@@ -183,7 +184,7 @@ def check_item(item, root_item, org_url_start, global_translation, local_transla
         # We don't need extra iterations for what we are using it for
         sitespeed_iterations = 1
         sitespeed_arg = (
-                '--shm-size=1g -b chrome '
+                f'--shm-size=1g -b {get_chromium_browser()} '
                 '--plugins.remove screenshot --plugins.remove html --plugins.remove metrics '
                 '--browsertime.screenshot false --screenshot false --screenshotLCP false '
                 '--browsertime.screenshotLCP false --chrome.cdp.performance false '

--- a/tests/energy_efficiency.py
+++ b/tests/energy_efficiency.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import json
 import os
 from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 from helpers.models import Rating
 from tests import energy_efficiency_carbon_percentiles
 from tests.sitespeed_base import get_result
@@ -272,7 +273,7 @@ def get_total_bytes_for_url(url, result_dict):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
     sitespeed_arg = (
-            '--shm-size=1g -b chrome '
+            f'--shm-size=1g -b {get_chromium_browser()} '
             '--plugins.remove screenshot --plugins.remove html --plugins.remove metrics '
             '--browsertime.screenshot false --screenshot false --screenshotLCP false '
             '--browsertime.screenshotLCP false --chrome.cdp.performance false '

--- a/tests/http_validator.py
+++ b/tests/http_validator.py
@@ -16,6 +16,7 @@ from helpers.sitespeed_helper import get_data_from_sitespeed
 from helpers.sri_helper import rate_sri
 from helpers.tls_helper import rate_transfer_layers
 from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 from helpers.models import Rating
 from tests.utils import change_url_to_test_url, dns_lookup,\
     get_translation, merge_dicts
@@ -841,7 +842,7 @@ def get_website_support_from_sitespeed(url, org_domain, configuration, browser, 
             f'{sitespeed_arg}')
     else:
         sitespeed_arg = (
-            '-b chrome '
+            f'-b {get_chromium_browser()} '
             '--chrome.cdp.performance false '
             '--browsertime.chrome.timeline false '
             '--browsertime.chrome.includeResponseBodies all '

--- a/tests/lint_base.py
+++ b/tests/lint_base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import subprocess
 import json
 from helpers.models import Rating
+from helpers.browser_helper import get_chromium_browser
 from helpers.setting_helper import get_config
 from tests.sitespeed_base import get_result
 from tests.utils import get_cache_path_for_file,\
@@ -167,7 +168,7 @@ def get_data_for_url(url):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
     sitespeed_arg = (
-            '--shm-size=1g -b chrome '
+            f'--shm-size=1g -b {get_chromium_browser()} '
             '--plugins.remove screenshot --plugins.remove html --plugins.remove metrics '
             '--browsertime.screenshot false --screenshot false --screenshotLCP false '
             '--browsertime.screenshotLCP false --chrome.cdp.performance false '

--- a/tests/page_not_found.py
+++ b/tests/page_not_found.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import urllib  # https://docs.python.org/3/library/urllib.parse.html
 from bs4 import BeautifulSoup
 from helpers.models import Rating
+from helpers.browser_helper import get_chromium_browser
 from tests.utils import get_guid,\
     get_http_content, get_translation
 from tests.sitespeed_base import get_result
@@ -55,7 +56,7 @@ def get_http_content_with_status(url):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
     sitespeed_arg = (
-            '--shm-size=1g -b chrome '
+            f'--shm-size=1g -b {get_chromium_browser()} '
             '--plugins.remove screenshot --plugins.remove html --plugins.remove metrics '
             '--browsertime.screenshot false --screenshot false --screenshotLCP false '
             '--browsertime.screenshotLCP false --chrome.cdp.performance false '

--- a/tests/performance_sitespeed_io.py
+++ b/tests/performance_sitespeed_io.py
@@ -6,8 +6,9 @@ import re
 import subprocess
 from datetime import datetime
 from helpers.models import Rating
-from tests.utils import get_dependency_version, get_translation
 from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
+from tests.utils import get_dependency_version, get_translation
 
 def get_result(arg):
     """
@@ -194,7 +195,7 @@ def validate_on_mobile_using_validator(url, validator_config):
     browertime_plugin_options = get_browsertime_plugin_options(validator_config)
     arg = (
         '--shm-size=1g '
-        '-b chrome '
+        f'-b {get_chromium_browser()} '
         '--mobile true '
         '--chrome.CPUThrottlingRate 3 '
         '--connectivity.profile 3gfast '
@@ -271,7 +272,7 @@ def validate_on_desktop_using_validator(url, validator_config):
 
     arg = (
         '--shm-size=1g '
-        '-b chrome '
+        f'-b {get_chromium_browser()} '
         '--connectivity.profile native '
         '--visualMetrics true '
         '--plugins.remove screenshot '
@@ -305,7 +306,7 @@ def validate_on_desktop(url):
     """
     arg = (
         '--shm-size=1g '
-        '-b chrome '
+        f'-b {get_chromium_browser()} '
         '--connectivity.profile native '
         '--visualMetrics true '
         '--plugins.remove screenshot '
@@ -336,7 +337,7 @@ def validate_on_mobile(url):
     """
     arg = (
         '--shm-size=1g '
-        '-b chrome '
+        f'-b {get_chromium_browser()} '
         '--mobile true '
         '--connectivity.profile 3gfast '
         '--visualMetrics true '

--- a/tests/software.py
+++ b/tests/software.py
@@ -12,9 +12,10 @@ from PIL import Image
 # https://docs.python.org/3/library/urllib.parse.html
 import packaging.version
 from helpers.models import Rating, DefaultInfo
+from helpers.browser_helper import get_chromium_browser
+from helpers.setting_helper import get_config
 from tests.sitespeed_base import get_result
 from tests.utils import get_http_content, get_translation, is_file_older_than
-from helpers.setting_helper import get_config
 
 # Debug flags for every category here,
 # this so we can print out raw values (so we can add more allowed once)
@@ -70,7 +71,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
         '--utc true '
         f'-n {sitespeed_iterations}')
 
-    if 'firefox' in get_config('tests.software.browser'):
+    if 'firefox' in get_config('tests.sitespeed.browser'):
         sitespeed_arg = (
             '-b firefox '
             '--firefox.includeResponseBodies all '
@@ -81,7 +82,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
             f'{sitespeed_arg}')
     else:
         sitespeed_arg = (
-            '-b chrome '
+            f'-b {get_chromium_browser()} '
             '--chrome.cdp.performance false '
             '--browsertime.chrome.timeline false '
             '--browsertime.chrome.includeResponseBodies all '

--- a/tests/tracking_validator.py
+++ b/tests/tracking_validator.py
@@ -7,10 +7,11 @@ import re
 from urllib.parse import urlparse
 from datetime import datetime, timedelta, date
 from helpers.models import Rating
+from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 from tests.utils import get_best_country_code, get_friendly_url_name,\
     get_translation, is_country_code_in_eu_or_on_exception_list
 from tests.sitespeed_base import get_result
-from helpers.setting_helper import get_config
 
 def get_domains_from_url(url):
     domains = set()
@@ -765,7 +766,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
 
-    sitespeed_arg = '--shm-size=1g -b chrome --plugins.remove screenshot --plugins.remove html --plugins.remove metrics --browsertime.screenshot false --screenshot false --screenshotLCP false --browsertime.screenshotLCP false --chrome.cdp.performance false --browsertime.chrome.timeline false --videoParams.createFilmstrip false --visualMetrics false --visualMetricsPerceptual false --visualMetricsContentful false --browsertime.headless true --browsertime.chrome.includeResponseBodies all --utc true --browsertime.chrome.args ignore-certificate-errors -n {0}'.format(
+    sitespeed_arg = f'--shm-size=1g -b {get_chromium_browser()} --plugins.remove screenshot --plugins.remove html --plugins.remove metrics --browsertime.screenshot false --screenshot false --screenshotLCP false --browsertime.screenshotLCP false --chrome.cdp.performance false --browsertime.chrome.timeline false --videoParams.createFilmstrip false --visualMetrics false --visualMetricsPerceptual false --visualMetricsContentful false --browsertime.headless true --browsertime.chrome.includeResponseBodies all --utc true --browsertime.chrome.args ignore-certificate-errors -n {0}'.format(
         sitespeed_iterations)
     if get_config('tests.sitespeed.xvfb'):
         sitespeed_arg += ' --xvfb'

--- a/tests/tracking_validator.py
+++ b/tests/tracking_validator.py
@@ -766,8 +766,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
 
-    sitespeed_arg = f'--shm-size=1g -b {get_chromium_browser()} --plugins.remove screenshot --plugins.remove html --plugins.remove metrics --browsertime.screenshot false --screenshot false --screenshotLCP false --browsertime.screenshotLCP false --chrome.cdp.performance false --browsertime.chrome.timeline false --videoParams.createFilmstrip false --visualMetrics false --visualMetricsPerceptual false --visualMetricsContentful false --browsertime.headless true --browsertime.chrome.includeResponseBodies all --utc true --browsertime.chrome.args ignore-certificate-errors -n {0}'.format(
-        sitespeed_iterations)
+    sitespeed_arg = f'--shm-size=1g -b {get_chromium_browser()} --plugins.remove screenshot --plugins.remove html --plugins.remove metrics --browsertime.screenshot false --screenshot false --screenshotLCP false --browsertime.screenshotLCP false --chrome.cdp.performance false --browsertime.chrome.timeline false --videoParams.createFilmstrip false --visualMetrics false --visualMetricsPerceptual false --visualMetricsContentful false --browsertime.headless true --browsertime.chrome.includeResponseBodies all --utc true --browsertime.chrome.args ignore-certificate-errors -n {sitespeed_iterations}'
     if get_config('tests.sitespeed.xvfb'):
         sitespeed_arg += ' --xvfb'
 

--- a/tests/w3c_base.py
+++ b/tests/w3c_base.py
@@ -4,11 +4,12 @@ import os
 import subprocess
 import json
 from helpers.models import Rating
+from helpers.setting_helper import get_config
+from helpers.browser_helper import get_chromium_browser
 from tests.sitespeed_base import get_result
 from tests.utils import get_cache_path_for_file,\
                         has_cache_file,\
                         set_cache_file
-from helpers.setting_helper import get_config
 
 def get_errors_for_url(test_type, url):
     """
@@ -103,7 +104,7 @@ def get_data_for_url(url):
     # We don't need extra iterations for what we are using it for
     sitespeed_iterations = 1
     sitespeed_arg = (
-            '--shm-size=1g -b chrome '
+            f'--shm-size=1g -b {get_chromium_browser()} '
             '--plugins.remove screenshot --plugins.remove html --plugins.remove metrics '
             '--browsertime.screenshot false --screenshot false --screenshotLCP false '
             '--browsertime.screenshotLCP false --chrome.cdp.performance false '


### PR DESCRIPTION
With this change you can use edge as browser for sitespeed based tests.
For now this is more or less useless for none windows users.
BUT for windows users, this setting makes it possible to use edge instead
of chrome,
meaning you don't need to download an extra browser just for testing.
Valid values are:
- chrome
- edge
NOTE: Firefox is not supported yet because of missing functionality making
it impossible to collect resource content.

Removed hardcoded browser `chrome` with new setting `test.sitespeed.browser`.
Also replacing previous software only setting `test.software.browser` with `test.sitespeed.browser`.