### PR TITLE
fix: KeyError in get_sri_candidates when tag has no src/href

### DIFF
--- a/helpers/sri_helper.py
+++ b/helpers/sri_helper.py
@@ -354,8 +354,8 @@ def append_with_src(req_domain, raw, obj):
     group_src = re.search(regex_src, raw, re.IGNORECASE)
     if group_src is not None:
         src = group_src.group('src')
-        obj['src'] = src
-        obj['src-same-origin'] = is_same_domain(src, req_domain)
+    obj['src'] = src
+    obj['src-same-origin'] = is_same_domain(src, req_domain) if src is not None else False
 
 def get_sri_candidates(req_domain, content):
     """


### PR DESCRIPTION
### Description
append_with_src only set 'src' and 'src-same-origin' keys when an href/src attribute was found. Tags without either attribute caused a KeyError on line 401 of get_sri_candidates.

Move the key assignments outside the conditional so both keys are always present. When no src is found, defaults to None and False.

Fixes #1461