### PR TITLE
fix(standard_files): addIssue signature mismatch crashes test 9 on unreachable sites

### DIFF
--- a/tests/standard_files.py
+++ b/tests/standard_files.py
@@ -117,8 +117,8 @@ def run_test(global_translation, url):
         addIssue(
             result_dict,
             'no-network',
-            global_translation('TEXT_SITE_UNAVAILABLE'),
-            result_dict['url'])
+            result_dict['url'],
+            global_translation('TEXT_SITE_UNAVAILABLE'))
 
         result_dict['groups'][domain]['issues'] = flatten_issues_dict(result_dict['groups'][domain]['issues'])
 
@@ -145,30 +145,27 @@ def addResolvedIssues(url, domain, result_dict):
             result_dict['groups'][domain]['issues'][rule_id]['severity'] = 'resolved'
             result_dict['groups'][domain]['issues'][rule_id]['category'] = rule['category']
 
-def addIssue(result_dict, rule_id, url):
+def addIssue(result_dict, rule_id, url, text=None):
     domain = get_domain(result_dict['url'])
+    sub_issue = {
+        'url': url,
+        'rule': rule_id,
+        'category': ALL_RULES[rule_id]['category'],
+        'severity': ALL_RULES[rule_id]['severity']
+    }
+    if text is not None:
+        sub_issue['text'] = text
+
     if rule_id not in result_dict['groups'][domain]['issues']:
         result_dict['groups'][domain]['issues'][rule_id] = {
             'test': 'standard-files',
             'rule': rule_id,
             'category': ALL_RULES[rule_id]['category'],
             'severity': ALL_RULES[rule_id]['severity'],
-            'subIssues': [
-                {
-                    'url': url,
-                    'rule': rule_id,
-                    'category': ALL_RULES[rule_id]['category'],
-                    'severity': ALL_RULES[rule_id]['severity']
-                }
-            ]
+            'subIssues': [sub_issue]
         }
     else:
-        result_dict['groups'][domain]['issues'][rule_id]['subIssues'].append({
-            'url': url,
-            'rule': rule_id,
-            'category': ALL_RULES[rule_id]['category'],
-            'severity': ALL_RULES[rule_id]['severity']
-        })
+        result_dict['groups'][domain]['issues'][rule_id]['subIssues'].append(sub_issue)
 
 
 def addResolvedIssue(result_dict, rule_id, url):


### PR DESCRIPTION
Fixes #1468 
## What this changes

Two minimal edits in `tests/standard_files.py`:

1. `addIssue()` accepts an optional fourth parameter `text=None`, stored on the sub-issue when provided
2. The call site in `run_test()`'s failure branch passes arguments in the correct order: `(result_dict, rule_id, url, text)`

## Backward compatibility

All ~25 existing 3-argument `addIssue` calls in this file work unchanged thanks to the default `text=None`. No other files need to be touched.

## Testing

Verified locally against:

- `https://bolagsverket.se` (previously crashed with `TypeError`) — now returns a graceful `no-network` result with the localised TEXT_SITE_UNAVAILABLE text attached to the sub-issue
- A normally responding site — output unchanged