### PR TITLE
Energy efficiency must not report a pass when HAR is missing

### DIFF
--- a/tests/energy_efficiency.py
+++ b/tests/energy_efficiency.py
@@ -313,7 +313,7 @@ def get_total_bytes_for_url(url, result_dict):
 
     browsertime_Hars = read_sites_from_directory(result_folder_name, origin_domain, -1, -1)
     if len(browsertime_Hars) < 1:
-        return -1
+        return None
 
     transfer_bytes = get_total_bytes(browsertime_Hars[0][0], result_dict)
     return transfer_bytes


### PR DESCRIPTION
get_total_bytes_for_url returned -1 when read_sites_from_directory yielded no HAR files (e.g. when Browsertime crashes and no measurement happens). The caller only checks for is None, so -1 slipped past the error handling and the test kept counting on negative bytes: format_bytes(-1) produced "Network size: -0.00 KB" and the page incorrectly received a 5.0 rating. Return None instead so the existing is None check triggers the error path (TEXT_SITE_UNAVAILABLE, failed=True).

Closes #1513 