### PR TITLE
Detect more accessibility overlays in the Software test (25)

### DIFF
--- a/defaults/a11y-overlays.json
+++ b/defaults/a11y-overlays.json
@@ -1,8 +1,21 @@
 {
     "overlays": [
         {
+            "name": "AccessiWay",
+            "description": "accessiBe's European reseller; own acswapp.com loader on top of the acsbapp.com engine",
+            "website": "https://www.accessiway.com",
+            "urls": [
+                {
+                    "url": "https://embeds.acswapp.com/"
+                },
+                {
+                    "url": "https://www.accessiway.com/"
+                }
+            ]
+        },
+        {
             "name": "AccessiBe",
-            "description": "Sometimes referred to as Accessiway?",
+            "description": "",
             "website": "https://accessibe.com",
             "urls": [
                 {
@@ -52,6 +65,58 @@
                 },
                 {
                     "url": "https://wsv3cdn.audioeye.com/"
+                }
+            ]
+        },
+        {
+            "name": "WCAGready/EaseAccess24",
+            "description": "Accessibility overlay served from easeaccess24.com",
+            "website": "https://www.wcagready.com",
+            "urls": [
+                {
+                    "url": "https://widget.easeaccess24.com/"
+                },
+                {
+                    "url": "https://app.easeaccess24.com/"
+                },
+                {
+                    "url": "https://ui.easeaccess24.com/"
+                },
+                {
+                    "url": "https://crawler.easeaccess24.com/"
+                }
+            ]
+        },
+        {
+            "name": "Elementor",
+            "description": "Elementor accessibility widget (cdn.elementor.com/a11y/), not the general page builder",
+            "website": "https://elementor.com/features/accessibility/",
+            "urls": [
+                {
+                    "url": "https://cdn.elementor.com/a11y/"
+                }
+            ]
+        },
+        {
+            "name": "Accessibly",
+            "description": "Accessibility overlay by On The Map",
+            "website": "https://accessibly.app",
+            "urls": [
+                {
+                    "url": "https://cdn.accessibly.app/"
+                }
+            ]
+        },
+        {
+            "name": "Eye-Able",
+            "description": "Accessibility overlay by Web Inclusion GmbH",
+            "website": "https://eye-able.com",
+            "urls": [
+                {
+                    "url": "https://eye-able.com/"
+                },
+                {
+                    "url": "https://eye-able-cdn.com/"
                 }
             ]
         }

--- a/defaults/software-rules.json
+++ b/defaults/software-rules.json
@@ -2,7 +2,20 @@
     "urls": [
         {
             "use": true,
-            "description": "AccessiBe - Sometimes referred to as Accessiway?",
+            "description": "AccessiWay - accessiBe's European reseller; uses its own acswapp.com loader on top of the acsbapp.com engine",
+            "website": "https://www.accessiway.com",
+            "match": "(?P<debug>acswapp\\.com|accessiway\\.com)",
+            "results": [
+                {
+                    "category": "a11y_overlay",
+                    "name": "AccessiWay",
+                    "precision": 0.6
+                }
+            ]
+        },
+        {
+            "use": true,
+            "description": "AccessiBe",
             "website": "https://accessibe.com",
             "match": "(?P<debug>acsbapp\\.com)",
             "results": [
@@ -35,6 +48,58 @@
                 {
                     "category": "a11y_overlay",
                     "name": "UserWay",
+                    "precision": 0.6
+                }
+            ]
+        },
+        {
+            "use": true,
+            "description": "WCAGready / EaseAccess24",
+            "website": "https://www.wcagready.com",
+            "match": "(?P<debug>easeaccess24\\.com|wcagready\\.com)",
+            "results": [
+                {
+                    "category": "a11y_overlay",
+                    "name": "WCAGready/EaseAccess24",
+                    "precision": 0.6
+                }
+            ]
+        },
+        {
+            "use": true,
+            "description": "Elementor accessibility widget (the /a11y/ path; not the general page builder)",
+            "website": "https://elementor.com/features/accessibility/",
+            "match": "(?P<debug>elementor\\.com\\/a11y\\/)",
+            "results": [
+                {
+                    "category": "a11y_overlay",
+                    "name": "Elementor",
+                    "precision": 0.6
+                }
+            ]
+        },
+        {
+            "use": true,
+            "description": "Accessibly (by On The Map)",
+            "website": "https://accessibly.app",
+            "match": "(?P<debug>accessibly\\.app)",
+            "results": [
+                {
+                    "category": "a11y_overlay",
+                    "name": "Accessibly",
+                    "precision": 0.6
+                }
+            ]
+        },
+        {
+            "use": true,
+            "description": "Eye-Able (matches CDN-hosted and self-hosted loader/widget)",
+            "website": "https://eye-able.com",
+            "match": "(?P<debug>eye-able|eyeable\\/ea_dynamicloading_|eyeable\\.js)",
+            "results": [
+                {
+                    "category": "a11y_overlay",
+                    "name": "Eye-Able",
                     "precision": 0.6
                 }
             ]


### PR DESCRIPTION
## What
Adds detection for five more accessibility overlays in the Software test (25), and separates AccessiWay from accessiBe.

| Overlay | Match signal |
| --- | --- |
| AccessiWay | `acswapp.com` / `accessiway.com` |
| WCAGready / EaseAccess24 | `easeaccess24.com` / `wcagready.com` |
| Elementor (a11y widget) | `cdn.elementor.com/a11y/` path only |
| Accessibly | `accessibly.app` |
| Eye-Able | `eye-able(.com/-cdn.com)`, self-hosted `eyeable/ea_dynamicloading_`, `eyeAble.js` |

## Why
- **AccessiWay** was reported as **accessiBe** because it resells the   same `acsbapp.com` engine; it now has its own rule via its `acswapp.com` loader. (Sites using AccessiWay still load the accessiBe engine, so both may be listed — this is intentional.)
- **Elementor** is a page builder, so detection is scoped to the `/a11y/` widget path to avoid flagging every Elementor site.
- **Accessibly** and **Eye-Able** are matched on stable domain/path tokens so CDN version bumps and self-hosted installs still resolve.

## Notes
- Changes are limited to overlay rules; no existing rule behaviour is altered (only the stale "Sometimes referred to as Accessiway?" note on the accessiBe rule was removed).
- Mirrored in `defaults/a11y-overlays.json`. 

## Files
- `defaults/software-rules.json`
- `defaults/a11y-overlays.json`

## Test
Verified the regexes match the real overlay resource URLs from wuerzburg.de, jlindeberg.com, wvv.de, websupport.se,
gotlandsboenden.se and tmeeting.se, while not matching the audited host domains.

Closing #1169 