### PR TITLE
Energy efficiency: only count requests belonging to the tested page

### DIFF
--- a/tests/energy_efficiency.py
+++ b/tests/energy_efficiency.py
@@ -245,8 +245,20 @@ def get_total_bytes(filename, result_dict):
         if 'log' in har_data:
             har_data = har_data['log']
 
+        # A HAR can contain more than one page, for example when a concurrent
+        # browsertime run ends up in the same browser session (crossed
+        # DevTools port) and navigates to another website mid-recording.
+        # Only requests belonging to the first page are the tested website's.
+        first_page_id = None
+        if 'pages' in har_data and len(har_data['pages']) > 0:
+            first_page_id = har_data['pages'][0].get('id')
+
         req_index = 1
         for entry in har_data["entries"]:
+            if first_page_id is not None and \
+                    entry.get('pageref', first_page_id) != first_page_id:
+                continue
+
             req = entry['request']
             res = entry['response']
 


### PR DESCRIPTION
## Problem

Test 22 (energy efficiency) sums **every** entry in the browsertime HAR without checking which page a request belongs to.

A HAR can contain more than one page: concurrent sitespeed runs on the same host race for the same Chrome DevTools port — browsertime's `getAvailablePort([9222, 9350])` test-binds and releases the port before Chrome actually binds it — and when two runs start within the same window, their CDP sessions cross and one run's network recording captures the other run's page navigation.

Observed in production: a test-22 result for factor10.com contained a complete page load of www.tierp.se (HAR entries 1–12 = factor10, 13–57 = tierp, recorded in one continuous session while a concurrent test loaded tierp.se). factor10 was billed 4.5 MB instead of ~276 KB and rated 2.70 instead of ~5.0.

## Fix

`get_total_bytes` now only counts entries whose `pageref` matches the first page in the HAR's `pages` array.

- Third-party subresources of the tested page (CDN fonts, analytics, etc.) are still counted — `pageref` groups by initiating page, not by domain.
- Entries without `pageref`, and HARs without a `pages` array (minified/older format), keep the old behavior of being counted.

## Validation

- Synthetic HARs: multi-page HAR counts only the first page; single-page, missing-`pageref`, missing-`pages`, and empty-`pages` HARs are unchanged; cross-domain subresources of the first page are still included.
- End-to-end: `default.py -t 22 -u https://webperf.se` → 5.0 rating, 356.77 KB; inspected the actual plugin-written HAR (`browsertime-<uuid>.har`) and confirmed it has `pages[0].id = page_1` with `pageref` on every entry, and that the filtered total matches the test output.

Follow-up in the next PR: the same filter plus an origin sanity check for the other HAR-consuming tests (21, 23, 25).