### PR TITLE
Bump plugin-standard-files to 2026.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "plugin-html": "2026.7.0",
     "plugin-javascript": "2026.7.0",
     "plugin-pagenotfound": "2026.7.0",
-    "plugin-standard-files": "2026.7.0",
+    "plugin-standard-files": "2026.8.0",
     "plugin-accessibility-statement": "2026.7.0",
     "plugin-webperf-core": "2026.7.0"
   },


### PR DESCRIPTION
## Summary
- Updates the `plugin-standard-files` sitespeed.io dependency from 2026.7.0 to 2026.8.0

## Test plan
- [x] Confirm sitespeed.io still runs cleanly with the updated plugin version